### PR TITLE
Scale two-handed tablet to actually fit in your hands

### DIFF
--- a/src/main/scala/li/cil/oc/client/renderer/TabletRenderer.scala
+++ b/src/main/scala/li/cil/oc/client/renderer/TabletRenderer.scala
@@ -19,7 +19,7 @@ object TabletRenderer {
   private val FrameBorder = 12
   private val BottomBorder = 20
   private val OffhandFaceSize = 1.26f
-  private val CenterFaceSize = 0.65f
+  private val CenterFaceSize = 1f
 
   @SubscribeEvent
   def onRenderHand(event: RenderHandEvent): Unit = {


### PR DESCRIPTION
Make tablet bigger, so that it actually sits in your hand as opposed to floats:
<img width="1920" height="1080" alt="2026-08-04_16 39 20" src="https://github.com/user-attachments/assets/5c8b118f-b99b-4546-9f7d-e553d945c3f4" />
