### PR TITLE
Fixing typo in the texture path used for the JEI recipe icons.

### DIFF
--- a/src/main/scala/li/cil/oc/integration/jei/CallbackDocHandler.scala
+++ b/src/main/scala/li/cil/oc/integration/jei/CallbackDocHandler.scala
@@ -85,7 +85,7 @@ object CallbackDocHandler {
 
     def initialize(guiHelper: IGuiHelper): Unit = {
       icon = new DrawableAnimatedIcon(
-        ResourceLocation.fromNamespaceAndPath(Settings.resourceDomain, "textures/items/tablet_on.png"),
+        ResourceLocation.fromNamespaceAndPath(Settings.resourceDomain, "textures/item/tablet_on.png"),
         0, 0, 16, 16, 16, 32,
         guiHelper.createTickTimer(20, 1, true), 0, 16
       )

--- a/src/main/scala/li/cil/oc/integration/jei/ManualUsageHandler.scala
+++ b/src/main/scala/li/cil/oc/integration/jei/ManualUsageHandler.scala
@@ -49,7 +49,7 @@ object ManualUsageHandler {
 
     def initialize(guiHelper: IGuiHelper): Unit = {
       icon = guiHelper.drawableBuilder(
-        ResourceLocation.fromNamespaceAndPath(Settings.resourceDomain, "textures/items/manual.png"),
+        ResourceLocation.fromNamespaceAndPath(Settings.resourceDomain, "textures/item/manual.png"),
         0, 0, 16, 16
       ).setTextureSize(16, 16).build()
     }


### PR DESCRIPTION
## Summary

This is a very small PR that fixes a typo in the texture path used for the JEI recipe icons.

## Changes

* Corrected the texture name referenced by the JEI integration.
* Restores the expected recipe icons by using the correct texture path.

I know this is a very minor contribution, but I thought it was worth fixing since it was a simple issue that could be resolved quickly.

Thank you for reviewing!
