### PR TITLE
Add power button to tablet GUI

### DIFF
--- a/src/main/scala/li/cil/oc/client/gui/Tablet.scala
+++ b/src/main/scala/li/cil/oc/client/gui/Tablet.scala
@@ -1,13 +1,55 @@
 package li.cil.oc.client.gui
 
 import li.cil.oc.common.menu
+import li.cil.oc.Localization
+import li.cil.oc.client.{PacketSender => ClientPacketSender}
+import li.cil.oc.client.Textures
+import net.minecraft.client.gui.components.Button
+import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.world.entity.player.Player
 import net.minecraft.network.chat.Component
 import net.minecraft.world.entity.player.Inventory
 
+import scala.jdk.CollectionConverters._
+import scala.collection.IterableOnce.iterableOnceExtensionMethods
+
 class Tablet(state: menu.Tablet, playerInventory: Inventory, name: Component)
   extends DynamicGuiContainer(state, playerInventory, name)
   with traits.LockedHotbar[menu.Tablet] {
+
+  protected var powerButton: ImageButton = _
+
+  override def render(graphics: GuiGraphics, mouseX: Int, mouseY: Int, dt: Float): Unit = {
+    // Issue: don't know how to get to the machine state from this class
+    powerButton.toggled = ???
+    super.render(graphics, mouseX, mouseY, dt)
+  }
+
+  override protected def init(): Unit = {
+    super.init()
+    //val machine = inventoryContainer.machine
+    //powerButton = new ImageButton(leftPos + 70, topPos + 34, 18, 18, (_: Button) => ClientPacketSender.sendComputerPower(machine, !machine.isRunning), Textures.GUI.ButtonPower, canToggle = true)
+    powerButton = new ImageButton(leftPos + 68, topPos + 34, 18, 18, (_: Button) => false, Textures.GUI.ButtonPower, canToggle = true)
+    addRenderableWidget(powerButton)
+  }
+
+  override protected def drawSecondaryForegroundLayer(graphics: GuiGraphics, mouseX: Int, mouseY: Int): Unit = {
+    super.drawSecondaryForegroundLayer(graphics, mouseX, mouseY)
+    //val machine = inventoryContainer.machine
+    if (powerButton.isMouseOver(mouseX, mouseY)) {
+      val tooltip = new java.util.ArrayList[Component]
+      tooltip.addAll(
+        // (if (machine.isRunning) Localization.Computer.TurnOff
+        // else Localization.Computer.TurnOn)
+        Localization.Computer.TurnOn
+          .linesIterator
+          .map(Component.literal)
+          .toSeq
+          .asJava
+      )
+      graphics.renderComponentTooltip(font, tooltip, mouseX - leftPos, mouseY - topPos)
+    }
+  }
 
   override def lockedStack = inventoryContainer.stack
 }

--- a/src/main/scala/li/cil/oc/common/item/Tablet.scala
+++ b/src/main/scala/li/cil/oc/common/item/Tablet.scala
@@ -168,9 +168,7 @@ class Tablet(props: Properties) extends Item(props) with traits.SimpleItem with 
         else {
           if (player.isCrouching) {
             if (!level.isClientSide) {
-              val tablet = Tablet.Server.get(stack, player)
-              tablet.machine.stop()
-              if (tablet.data.tier > Tier.One) player match {
+              player match {
                 case srvPlr: ServerPlayer => MenuTypes.openTabletGui(srvPlr, Tablet.get(stack, player))
                 case _ =>
               }

--- a/src/main/scala/li/cil/oc/common/menu/Tablet.scala
+++ b/src/main/scala/li/cil/oc/common/menu/Tablet.scala
@@ -13,7 +13,7 @@ class Tablet( id: Int, playerInventory: Inventory, val stack: ItemStack, tablet:
 
   override protected def getHostClass = classOf[TabletWrapper]
 
-  addSlot(new StaticComponentSlot(this, otherInventory, otherInventory.getContainerSize - 1, 80, 35, getHostClass, slot1, tier1) {
+  addSlot(new StaticComponentSlot(this, otherInventory, otherInventory.getContainerSize - 1, 90, 35, getHostClass, slot1, tier1) {
     override def mayPlace(stack: ItemStack): Boolean = {
       if (DriverScreen.worksWith(stack, getHostClass)) return false
       super.mayPlace(stack)


### PR DESCRIPTION
WIP.

Add power button to tablet GUI and make it so that shift-right click always opens the menu (even on a T1 tablet that can't take the interface upgrades), so that adding/removing hardware/floppies doesn't force a hard shutdown.