### PR TITLE
Complete tablet power controls

### DIFF
--- a/src/main/scala/li/cil/oc/client/PacketSender.scala
+++ b/src/main/scala/li/cil/oc/client/PacketSender.scala
@@ -38,6 +38,15 @@ object PacketSender {
     pb.sendToServer()
   }
 
+  def sendTabletPower(tablet: menu.Tablet, power: Boolean): Unit = {
+    val pb = new SimplePacketBuilder(PacketType.ComputerPower)
+
+    pb.writeInt(tablet.containerId)
+    pb.writeBoolean(power)
+
+    pb.sendToServer()
+  }
+
   def sendDriveMode(unmanaged: Boolean): Unit = {
     val pb = new SimplePacketBuilder(PacketType.DriveMode)
 

--- a/src/main/scala/li/cil/oc/client/gui/Tablet.scala
+++ b/src/main/scala/li/cil/oc/client/gui/Tablet.scala
@@ -1,13 +1,55 @@
 package li.cil.oc.client.gui
 
 import li.cil.oc.common.menu
+import li.cil.oc.Localization
+import li.cil.oc.client.{PacketSender => ClientPacketSender}
+import li.cil.oc.client.Textures
+import net.minecraft.client.gui.components.Button
+import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.world.entity.player.Player
 import net.minecraft.network.chat.Component
 import net.minecraft.world.entity.player.Inventory
 
+import scala.jdk.CollectionConverters._
+import scala.collection.IterableOnce.iterableOnceExtensionMethods
+
 class Tablet(state: menu.Tablet, playerInventory: Inventory, name: Component)
   extends DynamicGuiContainer(state, playerInventory, name)
   with traits.LockedHotbar[menu.Tablet] {
+
+  protected var powerButton: ImageButton = _
+
+  override def render(graphics: GuiGraphics, mouseX: Int, mouseY: Int, dt: Float): Unit = {
+    // Issue: don't know how to get to the machine state from this class
+    powerButton.toggled = ???
+    super.render(graphics, mouseX, mouseY, dt)
+  }
+
+  override protected def init(): Unit = {
+    super.init()
+    //val machine = inventoryContainer.machine
+    //powerButton = new ImageButton(leftPos + 70, topPos + 34, 18, 18, (_: Button) => ClientPacketSender.sendComputerPower(machine, !machine.isRunning), Textures.GUI.ButtonPower, canToggle = true)
+    powerButton = new ImageButton(leftPos + 68, topPos + 34, 18, 18, (_: Button) => false, Textures.GUI.ButtonPower, canToggle = true)
+    addRenderableWidget(powerButton)
+  }
+
+  override protected def drawSecondaryForegroundLayer(graphics: GuiGraphics, mouseX: Int, mouseY: Int): Unit = {
+    super.drawSecondaryForegroundLayer(graphics, mouseX, mouseY)
+    //val machine = inventoryContainer.machine
+    if (powerButton.isMouseOver(mouseX, mouseY)) {
+      val tooltip = new java.util.ArrayList[Component]
+      tooltip.addAll(
+        // (if (machine.isRunning) Localization.Computer.TurnOff
+        // else Localization.Computer.TurnOn)
+        Localization.Computer.TurnOn
+          .linesIterator
+          .map(Component.literal)
+          .toSeq
+          .asJava
+      )
+      graphics.renderComponentTooltip(font, tooltip, mouseX - leftPos, mouseY - topPos)
+    }
+  }
 
   override def lockedStack = inventoryContainer.stack
 }

--- a/src/main/scala/li/cil/oc/client/gui/Tablet.scala
+++ b/src/main/scala/li/cil/oc/client/gui/Tablet.scala
@@ -20,28 +20,23 @@ class Tablet(state: menu.Tablet, playerInventory: Inventory, name: Component)
   protected var powerButton: ImageButton = _
 
   override def render(graphics: GuiGraphics, mouseX: Int, mouseY: Int, dt: Float): Unit = {
-    // Issue: don't know how to get to the machine state from this class
-    powerButton.toggled = ???
+    powerButton.toggled = inventoryContainer.isRunning
     super.render(graphics, mouseX, mouseY, dt)
   }
 
   override protected def init(): Unit = {
     super.init()
-    //val machine = inventoryContainer.machine
-    //powerButton = new ImageButton(leftPos + 70, topPos + 34, 18, 18, (_: Button) => ClientPacketSender.sendComputerPower(machine, !machine.isRunning), Textures.GUI.ButtonPower, canToggle = true)
-    powerButton = new ImageButton(leftPos + 68, topPos + 34, 18, 18, (_: Button) => false, Textures.GUI.ButtonPower, canToggle = true)
+    powerButton = new ImageButton(leftPos + 68, topPos + 34, 18, 18, (_: Button) => ClientPacketSender.sendTabletPower(inventoryContainer, !inventoryContainer.isRunning), Textures.GUI.ButtonPower, canToggle = true)
     addRenderableWidget(powerButton)
   }
 
   override protected def drawSecondaryForegroundLayer(graphics: GuiGraphics, mouseX: Int, mouseY: Int): Unit = {
     super.drawSecondaryForegroundLayer(graphics, mouseX, mouseY)
-    //val machine = inventoryContainer.machine
     if (powerButton.isMouseOver(mouseX, mouseY)) {
       val tooltip = new java.util.ArrayList[Component]
       tooltip.addAll(
-        // (if (machine.isRunning) Localization.Computer.TurnOff
-        // else Localization.Computer.TurnOn)
-        Localization.Computer.TurnOn
+        (if (inventoryContainer.isRunning) Localization.Computer.TurnOff
+        else Localization.Computer.TurnOn)
           .linesIterator
           .map(Component.literal)
           .toSeq

--- a/src/main/scala/li/cil/oc/client/renderer/TabletRenderer.scala
+++ b/src/main/scala/li/cil/oc/client/renderer/TabletRenderer.scala
@@ -34,6 +34,7 @@ object TabletRenderer {
     val buffer = wrapper.flatMap(_.componentSlots.collectFirst {
       case Some(textBuffer: api.internal.TextBuffer) => textBuffer
     })
+    val powered = wrapper.exists(_.data.isRunning)
 
     // Never expose the baked icon's fake screen in-hand. Until the client
     // receives the authoritative buffer snapshot, render an empty tablet face;
@@ -46,7 +47,8 @@ object TabletRenderer {
       event.getInterpolatedPitch,
       event.getEquipProgress,
       event.getSwingProgress,
-      buffer)
+      buffer,
+      powered)
     event.setCanceled(true)
   }
 
@@ -57,17 +59,18 @@ object TabletRenderer {
                                 pitch: Float,
                                 equipProgress: Float,
                                 swingProgress: Float,
-                                textBuffer: Option[api.internal.TextBuffer]): Unit = {
+                                textBuffer: Option[api.internal.TextBuffer],
+                                powered: Boolean): Unit = {
     val player = Minecraft.getInstance.player
     if (player == null) return
 
     stack.pushPose()
     if (hand == InteractionHand.MAIN_HAND && player.getOffhandItem.isEmpty) {
-      renderCentered(stack, renderBuffer, packedLight, pitch, equipProgress, swingProgress, textBuffer)
+      renderCentered(stack, renderBuffer, packedLight, pitch, equipProgress, swingProgress, textBuffer, powered)
     }
     else {
       val arm = if (hand == InteractionHand.MAIN_HAND) player.getMainArm else player.getMainArm.getOpposite
-      renderAtSide(stack, renderBuffer, packedLight, arm, equipProgress, swingProgress, textBuffer, OffhandFaceSize)
+      renderAtSide(stack, renderBuffer, packedLight, arm, equipProgress, swingProgress, textBuffer, powered, OffhandFaceSize)
     }
     stack.popPose()
   }
@@ -79,6 +82,7 @@ object TabletRenderer {
                            equipProgress: Float,
                            swingProgress: Float,
                            textBuffer: Option[api.internal.TextBuffer],
+                           powered: Boolean,
                            faceSize: Float): Unit = {
     val minecraft = Minecraft.getInstance
     val side = if (arm == HumanoidArm.RIGHT) 1f else -1f
@@ -101,7 +105,7 @@ object TabletRenderer {
       -0.3f * Mth.sin(swingProgress * Math.PI.toFloat))
     stack.mulPose(Axis.XP.rotationDegrees(swing * -45f))
     stack.mulPose(Axis.YP.rotationDegrees(side * swing * -30f))
-    renderTablet(stack, textBuffer, faceSize)
+    renderTablet(stack, textBuffer, powered, faceSize)
     stack.popPose()
   }
 
@@ -111,7 +115,8 @@ object TabletRenderer {
                              pitch: Float,
                              equipProgress: Float,
                              swingProgress: Float,
-                             textBuffer: Option[api.internal.TextBuffer]): Unit = {
+                             textBuffer: Option[api.internal.TextBuffer],
+                             powered: Boolean): Unit = {
     val minecraft = Minecraft.getInstance
     val swingRoot = Mth.sqrt(swingProgress)
 
@@ -133,7 +138,7 @@ object TabletRenderer {
 
     stack.mulPose(Axis.XP.rotationDegrees(Mth.sin(swingRoot * Math.PI.toFloat) * 20f))
     stack.scale(2f, 2f, 2f)
-    renderTablet(stack, textBuffer, CenterFaceSize)
+    renderTablet(stack, textBuffer, powered, CenterFaceSize)
   }
 
   private def calculateMapTilt(pitch: Float): Float = {
@@ -188,7 +193,7 @@ object TabletRenderer {
     else playerRenderer.renderLeftHand(stack, renderBuffer, packedLight, minecraft.player)
   }
 
-  private def renderTablet(stack: PoseStack, textBuffer: Option[api.internal.TextBuffer], faceSize: Float): Unit = {
+  private def renderTablet(stack: PoseStack, textBuffer: Option[api.internal.TextBuffer], powered: Boolean, faceSize: Float): Unit = {
     val width = textBuffer.fold(160)(_.renderWidth)
     val height = textBuffer.fold(90)(_.renderHeight)
     if (width <= 0 || height <= 0) return
@@ -202,7 +207,6 @@ object TabletRenderer {
     stack.scale(scale, scale, -1f)
     stack.translate(-width * 0.5, -height * 0.5, 0)
 
-    val powered = textBuffer.exists(_.isRenderingEnabled)
     renderFrame(stack, width, height, powered)
 
     for (buffer <- textBuffer if buffer.isRenderingEnabled) {

--- a/src/main/scala/li/cil/oc/common/item/Tablet.scala
+++ b/src/main/scala/li/cil/oc/common/item/Tablet.scala
@@ -168,9 +168,7 @@ class Tablet(props: Properties) extends Item(props) with traits.SimpleItem with 
         else {
           if (player.isCrouching) {
             if (!level.isClientSide) {
-              val tablet = Tablet.Server.get(stack, player)
-              tablet.machine.stop()
-              if (tablet.data.tier > Tier.One) player match {
+              player match {
                 case srvPlr: ServerPlayer => MenuTypes.openTabletGui(srvPlr, Tablet.get(stack, player))
                 case _ =>
               }

--- a/src/main/scala/li/cil/oc/common/menu/Tablet.scala
+++ b/src/main/scala/li/cil/oc/common/menu/Tablet.scala
@@ -13,7 +13,7 @@ class Tablet( id: Int, playerInventory: Inventory, val stack: ItemStack, tablet:
 
   override protected def getHostClass = classOf[TabletWrapper]
 
-  addSlot(new StaticComponentSlot(this, otherInventory, otherInventory.getContainerSize - 1, 80, 35, getHostClass, slot1, tier1) {
+  addSlot(new StaticComponentSlot(this, otherInventory, otherInventory.getContainerSize - 1, 90, 35, getHostClass, slot1, tier1) {
     override def mayPlace(stack: ItemStack): Boolean = {
       if (DriverScreen.worksWith(stack, getHostClass)) return false
       super.mayPlace(stack)

--- a/src/main/scala/li/cil/oc/common/menu/Tablet.scala
+++ b/src/main/scala/li/cil/oc/common/menu/Tablet.scala
@@ -7,6 +7,7 @@ import net.minecraft.world.entity.player.Inventory
 import net.minecraft.world.item.ItemStack
 import net.minecraft.world.Container
 import net.minecraft.world.entity.player.Player
+import net.minecraft.world.inventory.DataSlot
 
 class Tablet( id: Int, playerInventory: Inventory, val stack: ItemStack, tablet: Container, slot1: String, tier1: Int)
   extends AbstractMenu(MenuTypes.TABLET.get(), id, playerInventory, tablet) {
@@ -21,6 +22,17 @@ class Tablet( id: Int, playerInventory: Inventory, val stack: ItemStack, tablet:
   })
 
   addPlayerInventorySlots(8, 84)
+
+  private val runningData = tablet match {
+    case wrapper: TabletWrapper =>
+      addDataSlot(new DataSlot {
+        override def get(): Int = if (wrapper.machine.isRunning) 1 else 0
+
+        override def set(value: Int): Unit = ()
+      })
+    case _ => addDataSlot(DataSlot.standalone)
+  }
+  def isRunning: Boolean = runningData.get != 0
 
   override def stillValid(player: Player) = player == playerInventory.player
 }

--- a/src/main/scala/li/cil/oc/server/PacketHandler.scala
+++ b/src/main/scala/li/cil/oc/server/PacketHandler.scala
@@ -112,6 +112,11 @@ object PacketHandler extends CommonPacketHandler {
             case _ => logForgedPacket(player)
           }
         }
+        case tablet: menu.Tablet if tablet.containerId == containerId =>
+          tablet.otherInventory match {
+            case wrapper: TabletWrapper => trySetComputerPower(wrapper.machine, setPower, player)
+            case _ => logForgedPacket(player)
+          }
         case _ => logForgedPacket(player)
       }
       case _ =>


### PR DESCRIPTION
Completes RobertCochran’s tablet-menu power-button WIP for 1.21.1.

- Adds a tablet menu button to start and stop the tablet’s machine.
- Synchronizes the button with the server-side running state.
- Keeps the tablet running when installed hardware or floppies are changed.
- Makes the in-hand tablet status LED reflect actual power state.

Based on the original work by @RobertCochran.