### PR TITLE
Add Create contraption support, initial train integration, and UUID clearing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -246,6 +246,10 @@ dependencies {
     // Create
     implementation("com.simibubi.create:create-${minecraft_version}:${create_version}:slim") { transitive = false }
     implementation("net.createmod.ponder:ponder-neoforge:${ponder_version}+mc${minecraft_version}")
+    // Create's MovementBehaviour API exposes Registrate's NonNullConsumer in
+    // a method signature. Keep it available while compiling the optional OC
+    // Create bridge as well as at dev-runtime.
+    compileOnly("com.tterrag.registrate:Registrate:${registrate_version}")
     runtimeOnly("dev.engine-room.flywheel:flywheel-neoforge-${minecraft_version}:${flywheel_version}")
     runtimeOnly("com.tterrag.registrate:Registrate:${registrate_version}")
     compileOnly(annotationProcessor("io.github.llamalad7:mixinextras-common:0.4.1"))

--- a/build.gradle
+++ b/build.gradle
@@ -250,6 +250,7 @@ dependencies {
     // a method signature. Keep it available while compiling the optional OC
     // Create bridge as well as at dev-runtime.
     compileOnly("com.tterrag.registrate:Registrate:${registrate_version}")
+    compileOnly("dev.engine-room.flywheel:flywheel-neoforge-${minecraft_version}:${flywheel_version}")
     runtimeOnly("dev.engine-room.flywheel:flywheel-neoforge-${minecraft_version}:${flywheel_version}")
     runtimeOnly("com.tterrag.registrate:Registrate:${registrate_version}")
     compileOnly(annotationProcessor("io.github.llamalad7:mixinextras-common:0.4.1"))

--- a/src/main/java/li/cil/oc/integration/create/CreateTrainEnvironment.java
+++ b/src/main/java/li/cil/oc/integration/create/CreateTrainEnvironment.java
@@ -1,0 +1,314 @@
+package li.cil.oc.integration.create;
+
+import com.simibubi.create.content.trains.entity.Train;
+import com.simibubi.create.content.trains.graph.DiscoveredPath;
+import com.simibubi.create.content.trains.graph.EdgePointType;
+import com.simibubi.create.content.trains.schedule.Schedule;
+import com.simibubi.create.content.trains.station.GlobalStation;
+import com.simibubi.create.content.trains.station.TrainEditPacket;
+import com.simibubi.create.foundation.utility.StringHelper;
+import li.cil.oc.api.Network;
+import li.cil.oc.api.driver.NamedBlock;
+import li.cil.oc.api.machine.Arguments;
+import li.cil.oc.api.machine.Callback;
+import li.cil.oc.api.machine.Context;
+import li.cil.oc.api.network.Environment;
+import li.cil.oc.api.network.Visibility;
+import li.cil.oc.api.prefab.AbstractManagedEnvironment;
+import net.createmod.catnip.data.Glob;
+import net.createmod.catnip.platform.CatnipServices;
+import net.minecraft.nbt.ByteTag;
+import net.minecraft.nbt.CollectionTag;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.DoubleTag;
+import net.minecraft.nbt.IntTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.NumericTag;
+import net.minecraft.nbt.StringTag;
+import net.minecraft.nbt.Tag;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.level.Level;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.WeakHashMap;
+import java.util.regex.PatternSyntaxException;
+
+/** The live Create train represented as an OC component on an onboard computer. */
+public final class CreateTrainEnvironment extends AbstractManagedEnvironment implements NamedBlock {
+    private static final Map<Environment, CreateTrainEnvironment> attached = new WeakHashMap<>();
+
+    private final Train train;
+    private final Level level;
+
+    private CreateTrainEnvironment(final Train train, final Level level) {
+        this.train = train;
+        this.level = level;
+        setNode(Network.newNode(this, Visibility.Network).withComponent("train").create());
+    }
+
+    /** Attach one train component to a computer that is currently inside a train carriage. */
+    public static synchronized void attach(final Environment computer, final Train train, final Level level) {
+        if (computer == null || computer.node() == null || train == null || level == null || attached.containsKey(computer))
+            return;
+        final CreateTrainEnvironment environment = new CreateTrainEnvironment(train, level);
+        attached.put(computer, environment);
+        computer.node().connect(environment.node());
+    }
+
+    /** Remove the transient component before Create tears down the moving computer. */
+    public static synchronized void detach(final Environment computer) {
+        final CreateTrainEnvironment environment = attached.remove(computer);
+        if (environment != null && environment.node() != null)
+            environment.node().remove();
+    }
+
+    @Override
+    public String preferredName() {
+        return "train";
+    }
+
+    @Override
+    public int priority() {
+        return 2;
+    }
+
+    private static Object[] result(final Object... values) {
+        return values;
+    }
+
+    @Callback(direct = true, doc = "function():string -- Get the train name.")
+    public Object[] getName(final Context context, final Arguments args) {
+        return result(train.name.getString());
+    }
+
+    @Callback(doc = "function(name:string) -- Set the train name.")
+    public Object[] setName(final Context context, final Arguments args) {
+        final String name = args.checkString(0);
+        train.name = Component.literal(name);
+        CatnipServices.NETWORK.sendToAllClients(new TrainEditPacket.TrainEditReturnPacket(
+                train.id, name, train.icon.getId(), train.mapColorIndex));
+        return result();
+    }
+
+    @Callback(direct = true, doc = "function():string -- Get the train UUID.")
+    public Object[] getId(final Context context, final Arguments args) {
+        return result(train.id.toString());
+    }
+
+    @Callback(direct = true, doc = "function():number -- Get the current train speed in blocks per tick.")
+    public Object[] getSpeed(final Context context, final Arguments args) {
+        return result(train.speed);
+    }
+
+    @Callback(direct = true, doc = "function():number -- Get the current throttle from 0 to 1.")
+    public Object[] getThrottle(final Context context, final Arguments args) {
+        return result(train.throttle);
+    }
+
+    @Callback(doc = "function(value:number) -- Set the throttle from 1/18 to 1.")
+    public Object[] setThrottle(final Context context, final Arguments args) {
+        train.throttle = Math.max(1.0 / 18.0, Math.min(1.0, args.checkDouble(0)));
+        return result(train.throttle);
+    }
+
+    @Callback(direct = true, doc = "function():boolean -- Whether the train has a forward conductor.")
+    public Object[] hasForwardConductor(final Context context, final Arguments args) {
+        return result(train.hasForwardConductor());
+    }
+
+    @Callback(direct = true, doc = "function():boolean -- Whether the train has a backward conductor.")
+    public Object[] hasBackwardConductor(final Context context, final Arguments args) {
+        return result(train.hasBackwardConductor());
+    }
+
+    @Callback(direct = true, doc = "function():boolean -- Whether the train is derailed.")
+    public Object[] isDerailed(final Context context, final Arguments args) {
+        return result(train.derailed);
+    }
+
+    @Callback(direct = true, doc = "function():string or nil -- Get the current station name.")
+    public Object[] getCurrentStation(final Context context, final Arguments args) {
+        final GlobalStation station = train.getCurrentStation();
+        return result(station == null ? null : station.name);
+    }
+
+    @Callback(direct = true, doc = "function():string -- Get the current schedule state.")
+    public Object[] getState(final Context context, final Arguments args) {
+        return result(train.runtime.state.toString());
+    }
+
+    @Callback(direct = true, doc = "function():boolean -- Whether schedule execution is paused.")
+    public Object[] isPaused(final Context context, final Arguments args) {
+        return result(train.runtime.paused);
+    }
+
+    @Callback(doc = "function(paused:boolean) -- Pause or resume schedule execution.")
+    public Object[] setPaused(final Context context, final Arguments args) {
+        train.runtime.paused = args.checkBoolean(0);
+        return result(train.runtime.paused);
+    }
+
+    @Callback(direct = true, doc = "function():number -- Get the zero-based current schedule entry.")
+    public Object[] getCurrentEntry(final Context context, final Arguments args) {
+        return result(train.runtime.currentEntry);
+    }
+
+    @Callback(direct = true, doc = "function():string -- Get the current schedule title.")
+    public Object[] getCurrentTitle(final Context context, final Arguments args) {
+        return result(train.runtime.currentTitle);
+    }
+
+    @Callback(direct = true, doc = "function():boolean -- Whether the train has a schedule.")
+    public Object[] hasSchedule(final Context context, final Arguments args) {
+        return result(train.runtime.getSchedule() != null);
+    }
+
+    @Callback(direct = true, doc = "function():table -- Get the train schedule in Create's schedule format.")
+    public Object[] getSchedule(final Context context, final Arguments args) {
+        final Schedule schedule = train.runtime.getSchedule();
+        if (schedule == null)
+            throw new IllegalStateException("train doesn't have a schedule");
+        return result(fromCompoundTag(schedule.write(level.registryAccess())));
+    }
+
+    @Callback(doc = "function(schedule:table) -- Replace the train schedule and start it.")
+    public Object[] setSchedule(final Context context, final Arguments args) {
+        final Schedule schedule = Schedule.fromTag(level.registryAccess(), toCompoundTag(args.checkTable(0)));
+        if (schedule.entries.isEmpty())
+            throw new IllegalArgumentException("Schedule must have at least one entry");
+        final boolean automatic = train.runtime.getSchedule() == null || train.runtime.isAutoSchedule;
+        train.runtime.setSchedule(schedule, automatic);
+        return result();
+    }
+
+    @Callback(doc = "function() -- Remove the schedule and cancel navigation.")
+    public Object[] clearSchedule(final Context context, final Arguments args) {
+        train.runtime.discardSchedule();
+        return result();
+    }
+
+    @Callback(direct = true, doc = "function(destination:string):boolean, string or nil -- Test whether a station is reachable.")
+    public Object[] canReach(final Context context, final Arguments args) {
+        final PathResult path = findPath(args.checkString(0));
+        return path.path != null ? result(true, null)
+                : result(false, path.destinationExists ? "cannot-reach" : "no-target");
+    }
+
+    @Callback(direct = true, doc = "function(destination:string):number or nil, string or nil -- Find the distance to a station.")
+    public Object[] distanceTo(final Context context, final Arguments args) {
+        final PathResult path = findPath(args.checkString(0));
+        return path.path != null ? result(path.path.distance, null)
+                : result(null, path.destinationExists ? "cannot-reach" : "no-target");
+    }
+
+    private PathResult findPath(final String destinationFilter) {
+        final String regex = Glob.toRegexPattern(destinationFilter, "");
+        boolean anyMatch = false;
+        final ArrayList<GlobalStation> stations = new ArrayList<>();
+        try {
+            if (train.graph != null) {
+                for (final GlobalStation station : train.graph.getPoints(EdgePointType.STATION)) {
+                    if (!station.name.matches(regex))
+                        continue;
+                    anyMatch = true;
+                    stations.add(station);
+                }
+            }
+        } catch (final PatternSyntaxException ignored) {
+        }
+        final DiscoveredPath path = train.navigation.findPathTo(stations, Double.MAX_VALUE);
+        return new PathResult(path, anyMatch);
+    }
+
+    private static Map<Object, Object> fromCompoundTag(final CompoundTag tag) {
+        return castMap(fromNbtTag(null, tag));
+    }
+
+    private static Object fromNbtTag(final String key, final Tag tag) {
+        final byte type = tag.getId();
+        if (type == Tag.TAG_BYTE && "Count".equals(key))
+            return ((NumericTag) tag).getAsByte();
+        if (type == Tag.TAG_BYTE)
+            return ((NumericTag) tag).getAsByte() != 0;
+        if (type == Tag.TAG_SHORT || type == Tag.TAG_INT || type == Tag.TAG_LONG)
+            return ((NumericTag) tag).getAsLong();
+        if (type == Tag.TAG_FLOAT || type == Tag.TAG_DOUBLE)
+            return ((NumericTag) tag).getAsDouble();
+        if (type == Tag.TAG_STRING)
+            return tag.getAsString();
+        if (type == Tag.TAG_LIST || type == Tag.TAG_BYTE_ARRAY || type == Tag.TAG_INT_ARRAY || type == Tag.TAG_LONG_ARRAY) {
+            final Map<Integer, Object> list = new LinkedHashMap<>();
+            final CollectionTag<?> collection = (CollectionTag<?>) tag;
+            for (int index = 0; index < collection.size(); index++)
+                list.put(index + 1, fromNbtTag(null, collection.get(index)));
+            return list;
+        }
+        if (type == Tag.TAG_COMPOUND) {
+            final Map<Object, Object> table = new LinkedHashMap<>();
+            final CompoundTag compound = (CompoundTag) tag;
+            for (final String compoundKey : compound.getAllKeys())
+                table.put(StringHelper.camelCaseToSnakeCase(compoundKey),
+                        fromNbtTag(compoundKey, compound.get(compoundKey)));
+            return table;
+        }
+        throw new IllegalArgumentException("unknown tag type " + tag.getType().getName());
+    }
+
+    private static CompoundTag toCompoundTag(final Map<?, ?> table) {
+        return (CompoundTag) toNbtTag(null, table);
+    }
+
+    private static Tag toNbtTag(final String key, final Object value) {
+        if (value instanceof Boolean bool)
+            return ByteTag.valueOf(bool);
+        if (value instanceof Byte || "count".equals(key))
+            return ByteTag.valueOf(((Number) value).byteValue());
+        if (value instanceof Number number)
+            return number.intValue() == number.doubleValue()
+                    ? IntTag.valueOf(number.intValue()) : DoubleTag.valueOf(number.doubleValue());
+        if (value instanceof String string)
+            return StringTag.valueOf(string);
+        if (value instanceof Map<?, ?> map && isArrayMap(map)) {
+            final ListTag list = new ListTag();
+            for (int index = 1; index <= map.size(); index++)
+                list.add(toNbtTag(null, getNumericKey(map, index)));
+            return list;
+        }
+        if (value instanceof Map<?, ?> map) {
+            final CompoundTag compound = new CompoundTag();
+            for (final Map.Entry<?, ?> entry : map.entrySet()) {
+                if (!(entry.getKey() instanceof String compoundKey))
+                    throw new IllegalArgumentException("table key is not of type string");
+                final String nbtKey = compoundKey.equals("id") && map.containsKey("count")
+                        ? "id" : StringHelper.snakeCaseToCamelCase(compoundKey);
+                compound.put(nbtKey, toNbtTag(compoundKey, entry.getValue()));
+            }
+            return compound;
+        }
+        throw new IllegalArgumentException("unknown object type " + (value == null ? "nil" : value.getClass().getName()));
+    }
+
+    private static boolean isArrayMap(final Map<?, ?> map) {
+        for (int index = 1; index <= map.size(); index++)
+            if (getNumericKey(map, index) == null)
+                return false;
+        return !map.isEmpty();
+    }
+
+    private static Object getNumericKey(final Map<?, ?> map, final int index) {
+        if (map.containsKey(index)) return map.get(index);
+        if (map.containsKey((double) index)) return map.get((double) index);
+        if (map.containsKey((long) index)) return map.get((long) index);
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<Object, Object> castMap(final Object value) {
+        return (Map<Object, Object>) value;
+    }
+
+    private record PathResult(DiscoveredPath path, boolean destinationExists) {
+    }
+}

--- a/src/main/resources/assets/opencomputers/sounds.json
+++ b/src/main/resources/assets/opencomputers/sounds.json
@@ -2,7 +2,7 @@
   "computer_running": {
     "category": "block",
     "sounds": [
-      {"name": "opencomputers:computer_running", "stream": true}
+      {"name": "opencomputers:computer_running", "stream": false}
     ]
   },
   "floppy_access": {

--- a/src/main/resources/assets/opencomputers/sounds.json
+++ b/src/main/resources/assets/opencomputers/sounds.json
@@ -2,7 +2,7 @@
   "computer_running": {
     "category": "block",
     "sounds": [
-      {"name": "opencomputers:computer_running", "stream": false}
+      {"name": "opencomputers:computer_running", "stream": false, "preload": true}
     ]
   },
   "floppy_access": {

--- a/src/main/scala/li/cil/oc/client/Sound.scala
+++ b/src/main/scala/li/cil/oc/client/Sound.scala
@@ -24,6 +24,10 @@ import net.neoforged.neoforge.event.level.LevelEvent
 
 object Sound {
   private val sources = mutable.WeakHashMap.empty[BlockEntity, PseudoLoopingStream]
+  // SoundEngine owns the actual sound instance. Keep a strong reference to
+  // every instance while it is playing so cleanup cannot lose it when the
+  // block entity key disappears from the weak map during a world transition.
+  private val activeSounds = mutable.Set.empty[PseudoLoopingStream]
 
   private val commandQueue = mutable.PriorityQueue.empty[Command]
 
@@ -84,11 +88,30 @@ object Sound {
 
   @SubscribeEvent
   def onWorldUnload(event: LevelEvent.Unload): Unit = {
+    stopAll()
+  }
+
+  def stopAll(): Unit = {
     commandQueue.synchronized(commandQueue.clear())
-    sources.synchronized(try sources.foreach(_._2.stop()) catch {
-      case _: Throwable => // Ignore.
-    })
-    sources.clear()
+    sources.synchronized {
+      try activeSounds.toSeq.foreach(stopSound) catch {
+        case _: Throwable => // Ignore.
+      }
+      activeSounds.clear()
+      sources.clear()
+    }
+  }
+
+  private def stopSound(sound: PseudoLoopingStream): Unit = {
+    sound.stop()
+    val minecraft = Minecraft.getInstance
+    if (minecraft != null && minecraft.getSoundManager != null) {
+      // Marking a TickableSoundInstance stopped only makes SoundEngine notice
+      // it on its next tick. Stop the channel too, so a world transition or
+      // resource reload cannot leave the fan playing in the next world.
+      minecraft.getSoundManager.stop(sound)
+    }
+    activeSounds -= sound
   }
 
   private abstract class Command(val when: Long, val blockEntity: WeakReference[BlockEntity]) extends Ordered[Command] {
@@ -103,9 +126,10 @@ object Sound {
         sources.synchronized {
           val current = sources.getOrElse(entity, null)
           if (current == null || !current.getLocation.getPath.equals(name)) {
-            if (current != null) current.stop()
+            if (current != null) stopSound(current)
             val sound = new PseudoLoopingStream(blockEntity, volume, name)
             sources(entity) = sound
+            activeSounds += sound
             Minecraft.getInstance.getSoundManager.play(sound)
           }
         }
@@ -118,7 +142,7 @@ object Sound {
       blockEntity.get.foreach { entity =>
         sources.synchronized {
           sources.remove(entity) match {
-            case Some(sound) => sound.stop()
+            case Some(sound) => stopSound(sound)
             case _ =>
           }
         }
@@ -151,6 +175,7 @@ object Sound {
     // Computer running sounds are world-positioned and must attenuate with
     // distance. Relative sounds are listener-relative and bypass world range.
     relative = false
+    attenuation = SoundInstance.Attenuation.LINEAR
     looping = true
     updatePosition()
 
@@ -168,7 +193,26 @@ object Sound {
     override def isStopped() = stopped
 
     // Required by ITickableSound, which is required to update position while playing
-    override def tick(): Unit = if (blockEntity.get.isDefined) updatePosition() else stop()
+    override def tick(): Unit = if (blockEntity.get.isDefined) updatePosition() else stopSound(this)
+
+    // Keep a hard positional cutoff even if a sound-engine implementation or
+    // resource definition ignores the normal attenuation distance.
+    override def getVolume(): Float = {
+      val listener = Minecraft.getInstance.player
+      val maxDistance = 16.0
+      if (listener == null) 0f
+      else {
+        val distance = math.sqrt(listener.distanceToSqr(x, y, z))
+        if (distance >= maxDistance) 0f
+        else {
+          // SoundEngine already applies one linear falloff. Apply a second,
+          // gentle linear factor here so the fan fades more noticeably with
+          // distance instead of staying prominent until the cutoff.
+          val distanceFade = (1.0 - distance / maxDistance).toFloat
+          super.getVolume() * distanceFade
+        }
+      }
+    }
 
     def stop(): Unit = {
       stopped = true

--- a/src/main/scala/li/cil/oc/client/Sound.scala
+++ b/src/main/scala/li/cil/oc/client/Sound.scala
@@ -148,7 +148,9 @@ object Sound {
 
     var stopped = false
     volume = subVolume * Settings.get.soundVolume
-    relative = blockEntity.get.isDefined
+    // Computer running sounds are world-positioned and must attenuate with
+    // distance. Relative sounds are listener-relative and bypass world range.
+    relative = false
     looping = true
     updatePosition()
 

--- a/src/main/scala/li/cil/oc/common/EventHandler.scala
+++ b/src/main/scala/li/cil/oc/common/EventHandler.scala
@@ -204,8 +204,7 @@ object EventHandler {
     Loot.disksForCyclingClient.clear()
     Loot.disksForCyclingClient ++= Loot.disksForCyclingServer.map(_.copy())
 
-    client.Sound.startLoop(null, "computer_running", 0f, 0)
-    scheduleServer(() => client.Sound.stopLoop(null))
+    client.Sound.stopAll()
   }
 
   @SubscribeEvent

--- a/src/main/scala/li/cil/oc/common/block/SimpleBlock.scala
+++ b/src/main/scala/li/cil/oc/common/block/SimpleBlock.scala
@@ -7,12 +7,13 @@ import li.cil.oc.common.blockentity
 import li.cil.oc.common.blockentity.traits.Colored
 import li.cil.oc.common.blockentity.traits.Inventory
 import li.cil.oc.common.blockentity.traits.Rotatable
+import li.cil.oc.common.block.property.PropertyRotatable
 import li.cil.oc.server.loot.LootFunctions
 import li.cil.oc.util.Color
 import li.cil.oc.util.Tooltip
 import net.minecraft.world.level.block.state.BlockBehaviour.Properties
 import net.minecraft.world.level.block.state.BlockState
-import net.minecraft.world.level.block.{Block, BaseEntityBlock => ContainerBlock, RenderShape => BlockRenderType}
+import net.minecraft.world.level.block.{Block, BaseEntityBlock => ContainerBlock, Mirror, RenderShape => BlockRenderType, Rotation}
 import net.minecraft.world.item.{TooltipFlag => ITooltipFlag, Item}
 import net.minecraft.world.entity.Entity
 import net.minecraft.world.entity.player.{Player => PlayerEntity}
@@ -112,6 +113,34 @@ abstract class SimpleBlock(props: Properties) extends ContainerBlock(props) {
   override def canHarvestBlock(state: BlockState, world: BlockGetter, pos: BlockPos, player: PlayerEntity) = true
 
   override def canBeReplaced(state: BlockState, ctx: BlockPlaceContext): Boolean = false
+
+  /**
+   * Vanilla/Create transform block states directly. This is separate from the
+   * legacy wrench path below, which rotates the block entity in-place.
+   */
+  @SuppressWarnings(Array("deprecation"))
+  override protected def rotate(state: BlockState, rotation: Rotation): BlockState = {
+    var result = state
+    if (state.hasProperty(PropertyRotatable.Facing)) {
+      result = result.setValue(PropertyRotatable.Facing, rotation.rotate(state.getValue(PropertyRotatable.Facing)))
+    }
+    if (state.hasProperty(PropertyRotatable.Yaw)) {
+      result = result.setValue(PropertyRotatable.Yaw, rotation.rotate(state.getValue(PropertyRotatable.Yaw)))
+    }
+    result
+  }
+
+  @SuppressWarnings(Array("deprecation"))
+  override protected def mirror(state: BlockState, mirror: Mirror): BlockState = {
+    var result = state
+    if (state.hasProperty(PropertyRotatable.Facing)) {
+      result = result.setValue(PropertyRotatable.Facing, mirror.mirror(state.getValue(PropertyRotatable.Facing)))
+    }
+    if (state.hasProperty(PropertyRotatable.Yaw)) {
+      result = result.setValue(PropertyRotatable.Yaw, mirror.mirror(state.getValue(PropertyRotatable.Yaw)))
+    }
+    result
+  }
   
   def getValidRotations(world: World, pos: BlockPos): Array[Direction] = validRotations_
 

--- a/src/main/scala/li/cil/oc/common/blockentity/traits/BaseBlockEntity.scala
+++ b/src/main/scala/li/cil/oc/common/blockentity/traits/BaseBlockEntity.scala
@@ -7,6 +7,7 @@ import li.cil.oc.client.Sound
 import li.cil.oc.common.SaveHandler
 import li.cil.oc.util.{BlockPosition, SideTracker}
 import net.minecraft.core.HolderLookup
+import net.minecraft.core.{BlockPos, Direction}
 import net.minecraft.core.component.{DataComponentHolder, DataComponentMap, DataComponentPatch, DataComponentType, PatchedDataComponentMap}
 import net.minecraft.nbt.{CompoundTag, NbtOps}
 import net.minecraft.network.Connection
@@ -14,9 +15,59 @@ import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket
 import net.neoforged.api.distmarker.{Dist, OnlyIn}
 import net.neoforged.neoforge.client.model.data.ModelProperty
 import net.neoforged.neoforge.common.MutableDataComponentHolder
+import net.minecraft.world.level.Level
+import net.minecraft.world.level.block.state.BlockState
+import net.minecraft.world.phys.Vec3
+
+import java.util.function.UnaryOperator
 
 trait BaseBlockEntity extends net.minecraft.world.level.block.entity.BlockEntity {
   private final val IsServerDataTag = Settings.namespace + "isServerData"
+
+  // Create keeps captured block entities off-world while a contraption moves.
+  // These helpers live here because Rotatable and RedstoneAware are sibling
+  // traits, not children of Environment.
+  protected var movingLevel: Level = null
+  protected var movingPosition: Vec3 = null
+  protected var movingRotation: UnaryOperator[Vec3] = null
+  protected var movingState: BlockState = null
+
+  def isMoving: Boolean = movingPosition != null
+
+  def beginMoving(level: Level, position: Vec3, rotation: UnaryOperator[Vec3], state: BlockState): Unit = {
+    movingLevel = level
+    movingPosition = position
+    movingRotation = rotation
+    movingState = state
+    initialize()
+  }
+
+  def updateMovingPosition(position: Vec3, rotation: UnaryOperator[Vec3], state: BlockState): Unit = {
+    movingPosition = position
+    movingRotation = rotation
+    movingState = state
+  }
+
+  def movingBlockPos: BlockPos = if (movingPosition == null) getBlockPos else BlockPos.containing(movingPosition)
+
+  def movingBlockState: BlockState = if (movingState == null) getBlockState else movingState
+
+  def movingDirection(side: Direction): Direction = {
+    if (movingRotation == null) side
+    else {
+      val vector = movingRotation.apply(new Vec3(side.getStepX, side.getStepY, side.getStepZ))
+      Direction.getNearest(vector.x, vector.y, vector.z)
+    }
+  }
+
+  def movingNeighbor(side: Direction): BlockPos = movingBlockPos.relative(movingDirection(side))
+
+  def endMoving(): Unit = {
+    movingLevel = null
+    movingPosition = null
+    movingRotation = null
+    movingState = null
+  }
 
   def x: Int = getBlockPos.getX
 

--- a/src/main/scala/li/cil/oc/common/blockentity/traits/Computer.scala
+++ b/src/main/scala/li/cil/oc/common/blockentity/traits/Computer.scala
@@ -61,7 +61,7 @@ trait Computer extends Environment with ComponentInventory with Rotatable with B
     if (value) {
       hasErrored = false
     }
-    if (getLevel != null) {
+    if (getLevel != null && !isMoving) {
       getLevel.sendBlockUpdated(getBlockPos, getLevel.getBlockState(getBlockPos), getLevel.getBlockState(getBlockPos), 3)
       if (getLevel.isClientSide) {
         runSound.foreach(sound =>
@@ -130,6 +130,22 @@ trait Computer extends Environment with ComponentInventory with Rotatable with B
 
   protected def updateComputer(): Unit = {
     machine.update()
+  }
+
+  /** Used by the optional Create integration while this block entity is off-world. */
+  def tickMoving(): Unit = updateEntity()
+
+  /** Save the live machine/component state back into Create's captured NBT. */
+  override def saveMovingState(nbt: CompoundTag, provider: HolderLookup.Provider): Unit = saveAdditional(nbt, provider)
+
+  /** Dispose the temporary machine and its component nodes before reassembly. */
+  override def disposeMoving(): Unit = {
+    disconnectComponents()
+    // Do not call machine.stop() here. That only queues a deferred close,
+    // while Create is about to throw this temporary host away. Removing the
+    // machine node closes it synchronously and avoids the old fake host
+    // waking up after the real block entity has been rebuilt.
+    super.disposeMoving()
   }
 
   protected def onRunningChanged(): Unit = {

--- a/src/main/scala/li/cil/oc/common/blockentity/traits/Computer.scala
+++ b/src/main/scala/li/cil/oc/common/blockentity/traits/Computer.scala
@@ -136,15 +136,18 @@ trait Computer extends Environment with ComponentInventory with Rotatable with B
   def tickMoving(): Unit = updateEntity()
 
   /** Save the live machine/component state back into Create's captured NBT. */
-  override def saveMovingState(nbt: CompoundTag, provider: HolderLookup.Provider): Unit = saveAdditional(nbt, provider)
+  override def saveMovingState(nbt: CompoundTag, provider: HolderLookup.Provider): Unit = {
+    saveAdditional(nbt, provider)
+    // One-shot marker. A normal chunk save writes fresh NBT and drops it after
+    // the restored machine has consumed the grace period.
+    nbt.putInt(MovingRestoreGraceTag, 40)
+  }
 
   /** Dispose the temporary machine and its component nodes before reassembly. */
   override def disposeMoving(): Unit = {
-    disconnectComponents()
-    // Do not call machine.stop() here. That only queues a deferred close,
-    // while Create is about to throw this temporary host away. Removing the
-    // machine node closes it synchronously and avoids the old fake host
-    // waking up after the real block entity has been rebuilt.
+    // Removing the machine node closes the VM synchronously, then its normal
+    // onDisconnect callback removes internal components. Doing that cleanup
+    // first would feed fake component_removed events to the still-live VM.
     super.disposeMoving()
   }
 
@@ -166,6 +169,13 @@ trait Computer extends Environment with ComponentInventory with Rotatable with B
   private final val HasErroredTag = Settings.namespace + "hasErrored"
   private final val IsRunningTag = Settings.namespace + "isRunning"
   private final val UsersTag = Settings.namespace + "users"
+  private final val MovingRestoreGraceTag = Settings.namespace + "movingRestoreGrace"
+  private var pendingMovingRestoreGrace = 0
+
+  override def loadAdditional(nbt: CompoundTag, provider: HolderLookup.Provider): Unit = {
+    pendingMovingRestoreGrace = nbt.getInt(MovingRestoreGraceTag)
+    super.loadAdditional(nbt, provider)
+  }
 
   override def loadComponentsForServer(holder: DataComponentHolder): Unit = {
     super.loadComponentsForServer(holder)
@@ -186,6 +196,14 @@ trait Computer extends Environment with ComponentInventory with Rotatable with B
 
   private def loadMachineData(holder: DataComponentHolder): Unit = {
     machine.loadData(holder)
+    if (pendingMovingRestoreGrace > 0) {
+      machine match {
+        case implementation: li.cil.oc.server.machine.Machine =>
+          implementation.beginComponentRestoreGrace(pendingMovingRestoreGrace)
+        case _ =>
+      }
+      pendingMovingRestoreGrace = 0
+    }
 
     // Kickstart initialization to avoid values getting overwritten by
     // loadForClient if that packet is handled after a manual

--- a/src/main/scala/li/cil/oc/common/blockentity/traits/Environment.scala
+++ b/src/main/scala/li/cil/oc/common/blockentity/traits/Environment.scala
@@ -14,13 +14,29 @@ import net.neoforged.neoforge.client.model.data.{ModelData, ModelProperty}
 trait Environment extends BaseBlockEntity with network.Environment with network.EnvironmentHost {
   protected var isChangeScheduled = false
 
-  override def getEnvironmentLevel: Level = getLevel
+  override def getEnvironmentLevel: Level = if (movingLevel != null) movingLevel else getLevel
 
-  override def xPosition: Double = x + 0.5
+  override def xPosition: Double = if (movingPosition != null) movingPosition.x else x + 0.5
 
-  override def yPosition: Double = y + 0.5
+  override def yPosition: Double = if (movingPosition != null) movingPosition.y else y + 0.5
 
-  override def zPosition: Double = z + 0.5
+  override def zPosition: Double = if (movingPosition != null) movingPosition.z else z + 0.5
+
+  /** Save a captured environment while Create still owns its off-world NBT. */
+  def saveMovingState(nbt: CompoundTag, provider: HolderLookup.Provider): Unit = saveAdditional(nbt, provider)
+
+  /** Remove the temporary OC node before Create places the real block entity. */
+  def disposeMoving(): Unit = {
+    Option(node).foreach(_.remove())
+    this match {
+      case sidedEnvironment: SidedEnvironment =>
+        for (side <- Direction.values) {
+          Option(sidedEnvironment.sidedNode(side)).foreach(_.remove())
+        }
+      case _ =>
+    }
+    endMoving()
+  }
 
   override def markChanged(): Unit = if (this.isInstanceOf[Tickable]) isChangeScheduled = true else this.setChanged()
 
@@ -30,7 +46,7 @@ trait Environment extends BaseBlockEntity with network.Environment with network.
 
   override protected def initialize(): Unit = {
     super.initialize()
-    if (isServer) {
+    if (isServer && !isMoving) {
       EventHandler.scheduleServer(this)
     }
   }

--- a/src/main/scala/li/cil/oc/common/blockentity/traits/Inventory.scala
+++ b/src/main/scala/li/cil/oc/common/blockentity/traits/Inventory.scala
@@ -71,7 +71,8 @@ trait Inventory extends BaseBlockEntity with container.Inventory {
   // ----------------------------------------------------------------------- //
 
   override def stillValid(player: Player) =
-    player.distanceToSqr(x + 0.5, y + 0.5, z + 0.5) <= 64
+    if (isMoving) player.distanceToSqr(movingPosition.x, movingPosition.y, movingPosition.z) <= 64
+    else player.distanceToSqr(x + 0.5, y + 0.5, z + 0.5) <= 64
 
   // ----------------------------------------------------------------------- //
 

--- a/src/main/scala/li/cil/oc/common/blockentity/traits/RedstoneAware.scala
+++ b/src/main/scala/li/cil/oc/common/blockentity/traits/RedstoneAware.scala
@@ -132,7 +132,13 @@ trait RedstoneAware extends RotationAware {
     }
   }
 
-  def updateRedstoneInput(side: Direction): Unit = setInput(side, BundledRedstone.computeInput(position, side))
+  def updateRedstoneInput(side: Direction): Unit = {
+    val inputPosition = if (isMoving) {
+      li.cil.oc.util.BlockPosition(movingBlockPos, getLevel)
+    } else position
+    val inputSide = if (isMoving) movingDirection(side) else side
+    setInput(side, BundledRedstone.computeInput(inputPosition, inputSide))
+  }
 
   // ----------------------------------------------------------------------- //
 
@@ -171,16 +177,21 @@ trait RedstoneAware extends RotationAware {
 
   protected def onRedstoneOutputEnabledChanged(): Unit = {
     if (getLevel != null) {
-      getLevel.updateNeighborsAt(getBlockPos, getBlockState.getBlock)
+      val blockPos = if (isMoving) movingBlockPos else getBlockPos
+      val block = if (isMoving) movingBlockState.getBlock else getBlockState.getBlock
+      getLevel.updateNeighborsAt(blockPos, block)
       if (isServer) ServerPacketSender.sendRedstoneState(this)
       else getLevel.sendBlockUpdated(getBlockPos, getLevel.getBlockState(getBlockPos), getLevel.getBlockState(getBlockPos), 3)
     }
   }
 
   protected def onRedstoneOutputChanged(side: Direction): Unit = {
-    val blockPos = BlockPosHelper.relative(getBlockPos, side)
-    getLevel.neighborChanged(blockPos, getBlockState.getBlock, blockPos)
-    getLevel.updateNeighborsAtExceptFromFacing(blockPos, getLevel.getBlockState(blockPos).getBlock, side.getOpposite)
+    val sourcePos = if (isMoving) movingBlockPos else getBlockPos
+    val sourceBlock = if (isMoving) movingBlockState.getBlock else getBlockState.getBlock
+    val outputSide = if (isMoving) movingDirection(side) else side
+    val blockPos = if (isMoving) movingNeighbor(side) else BlockPosHelper.relative(sourcePos, side)
+    getLevel.neighborChanged(blockPos, sourceBlock, sourcePos)
+    getLevel.updateNeighborsAtExceptFromFacing(blockPos, getLevel.getBlockState(blockPos).getBlock, outputSide.getOpposite)
 
     if (isServer) ServerPacketSender.sendRedstoneState(this)
     else getLevel.sendBlockUpdated(getBlockPos, getLevel.getBlockState(getBlockPos), getLevel.getBlockState(getBlockPos), 3)

--- a/src/main/scala/li/cil/oc/common/blockentity/traits/Rotatable.scala
+++ b/src/main/scala/li/cil/oc/common/blockentity/traits/Rotatable.scala
@@ -62,6 +62,10 @@ trait Rotatable extends RotationAware with internal.Rotatable {
         trySetPitchYaw(Direction.NORTH, yaw)
     }
 
+  /** Public bridge for integrations that transform a block entity off-world. */
+  def setFromPitchAndYaw(newPitch: Direction, newYaw: Direction): Boolean =
+    trySetPitchYaw(newPitch, newYaw)
+
   def invertRotation() =
     trySetPitchYaw(pitch match {
       case Direction.DOWN | Direction.UP => pitch.getOpposite

--- a/src/main/scala/li/cil/oc/common/blockentity/traits/Rotatable.scala
+++ b/src/main/scala/li/cil/oc/common/blockentity/traits/Rotatable.scala
@@ -26,7 +26,10 @@ trait Rotatable extends RotationAware with internal.Rotatable {
   // Accessors
   // ----------------------------------------------------------------------- //
 
-  def pitch = if (getLevel != null && getLevel.isLoaded(getBlockPos)) getLevel.getBlockState(getBlockPos) match {
+  def pitch = if (isMoving) movingBlockState match {
+    case rotatable if rotatable.getProperties.contains(PropertyRotatable.Pitch) => rotatable.getValue(PropertyRotatable.Pitch)
+    case _ => Direction.NORTH
+  } else if (getLevel != null && getLevel.isLoaded(getBlockPos)) getLevel.getBlockState(getBlockPos) match {
     case rotatable if rotatable.getProperties.contains(PropertyRotatable.Pitch) => rotatable.getValue(PropertyRotatable.Pitch)
     case _ => Direction.NORTH
   } else null
@@ -37,7 +40,11 @@ trait Rotatable extends RotationAware with internal.Rotatable {
       case _ => Direction.NORTH
     }, yaw)
 
-  def yaw = if (getLevel != null && getLevel.isLoaded(getBlockPos)) getLevel.getBlockState(getBlockPos) match {
+  def yaw = if (isMoving) movingBlockState match {
+    case rotatable if rotatable.getProperties.contains(PropertyRotatable.Yaw) => rotatable.getValue(PropertyRotatable.Yaw)
+    case rotatable if rotatable.getProperties.contains(PropertyRotatable.Facing) => rotatable.getValue(PropertyRotatable.Facing)
+    case _ => Direction.SOUTH
+  } else if (getLevel != null && getLevel.isLoaded(getBlockPos)) getLevel.getBlockState(getBlockPos) match {
     case rotatable if rotatable.getProperties.contains(PropertyRotatable.Yaw) => rotatable.getValue(PropertyRotatable.Yaw)
     case rotatable if rotatable.getProperties.contains(PropertyRotatable.Facing) => rotatable.getValue(PropertyRotatable.Facing)
     case _ => Direction.SOUTH

--- a/src/main/scala/li/cil/oc/common/blockentity/traits/TextBuffer.scala
+++ b/src/main/scala/li/cil/oc/common/blockentity/traits/TextBuffer.scala
@@ -40,7 +40,7 @@ trait TextBuffer extends Environment with Tickable {
 
   /** Create renders captured screens in a virtual level, but packets use the real client level. */
   def registerMovingClientBuffer(level: Level): Unit = buffer match {
-    case moving: li.cil.oc.common.component.TextBuffer =>
+    case moving: li.cil.oc.common.component.TextBuffer if movingClientLevel ne level =>
       movingClientLevel = level
       moving.registerClientBufferOnLevel(level)
     case _ =>

--- a/src/main/scala/li/cil/oc/common/blockentity/traits/TextBuffer.scala
+++ b/src/main/scala/li/cil/oc/common/blockentity/traits/TextBuffer.scala
@@ -7,13 +7,16 @@ import li.cil.oc.api.internal
 import li.cil.oc.api.network.Node
 import li.cil.oc.common.datacomponents.CompoundStorage
 import net.minecraft.core.HolderLookup
+import net.minecraft.core.component.DataComponentHolder
 import net.neoforged.api.distmarker.Dist
 import net.neoforged.api.distmarker.OnlyIn
 import net.minecraft.nbt.{CompoundTag, NbtOps}
+import net.minecraft.world.level.Level
 
 trait TextBuffer extends Environment with Tickable {
   private final val ClientBufferComponentsTag = Settings.namespace + "clientBufferComponents"
   private var pendingServerBufferData: CompoundTag = _
+  private var movingClientLevel: Level = _
   lazy val buffer: internal.TextBuffer = {
     val screenItem = api.Items.get(Constants.BlockName.ScreenTier1).createItemStack(1)
     val buffer = api.Driver.driverFor(screenItem, getClass).createEnvironment(screenItem, this).asInstanceOf[api.internal.TextBuffer]
@@ -35,6 +38,21 @@ trait TextBuffer extends Environment with Tickable {
     }
   }
 
+  /** Create renders captured screens in a virtual level, but packets use the real client level. */
+  def registerMovingClientBuffer(level: Level): Unit = buffer match {
+    case moving: li.cil.oc.common.component.TextBuffer =>
+      movingClientLevel = level
+      moving.registerClientBufferOnLevel(level)
+    case _ =>
+  }
+
+  def unregisterMovingClientBuffer(): Unit = buffer match {
+    case moving: li.cil.oc.common.component.TextBuffer if movingClientLevel != null =>
+      moving.unregisterClientBufferOnLevel(movingClientLevel)
+      movingClientLevel = null
+    case _ =>
+  }
+
   // ----------------------------------------------------------------------- //
 
   private def reapplyTierToBuffer(): Unit = {
@@ -48,6 +66,22 @@ trait TextBuffer extends Environment with Tickable {
     val (maxWidth, maxHeight) = Settings.screenResolutionsByTier(tier)
     buffer.setMaximumResolution(maxWidth, maxHeight)
     buffer.setMaximumColorDepth(Settings.screenDepthsByTier(tier))
+  }
+
+  override def loadComponentsForClient(holder: DataComponentHolder): Unit = {
+    super.loadComponentsForClient(holder)
+    // BaseBlockEntity loads the legacy/client NBT before it loads OC's
+    // components, so tier still has the constructor default during loadForClient.
+    // Do this again after Screen.loadComponentsCommon has supplied the real tier.
+    reapplyTierToBuffer()
+  }
+
+  override def loadComponentsForServer(holder: DataComponentHolder): Unit = {
+    super.loadComponentsForServer(holder)
+    // The moving Screen is reconstructed from Create's NBT just like a client
+    // render Screen: component loading supplies its real tier after the buffer
+    // may already have been forced by loadForServer.
+    reapplyTierToBuffer()
   }
 
   override def loadForServer(nbt: CompoundTag, provider: HolderLookup.Provider): Unit = {

--- a/src/main/scala/li/cil/oc/common/component/TextBuffer.scala
+++ b/src/main/scala/li/cil/oc/common/component/TextBuffer.scala
@@ -27,6 +27,7 @@ import net.minecraft.world.InteractionHand
 import net.minecraft.world.entity.player.Player
 import net.minecraft.world.item.component.CustomData
 import net.minecraft.world.level.ChunkPos
+import net.minecraft.world.level.Level
 import net.neoforged.api.distmarker.{Dist, OnlyIn}
 import net.neoforged.bus.api.SubscribeEvent
 import net.neoforged.neoforge.common.MutableDataComponentHolder
@@ -107,6 +108,14 @@ class TextBuffer(val host: EnvironmentHost) extends AbstractManagedEnvironment w
     // terminal input appear only after closing and reopening the GUI.
     if (!isInitialized) TextBuffer.registerClientBuffer(this)
   }
+
+  /** Register a captured Create screen with the real client world. */
+  def registerClientBufferOnLevel(level: Level): Unit =
+    TextBuffer.registerClientBuffer(this, level)
+
+  /** Remove a captured Create screen from the client tracker after disassembly. */
+  def unregisterClientBufferOnLevel(level: Level): Unit =
+    TextBuffer.unregisterClientBuffer(this, level)
 
   def isInitialized: Boolean = syncCooldown < 0
 
@@ -556,8 +565,18 @@ object TextBuffer {
   }
 
   def registerClientBuffer(t: TextBuffer): Unit = {
-    val level = t.host.getEnvironmentLevel
+    registerClientBuffer(t, t.host.getEnvironmentLevel)
+  }
+
+  def registerClientBuffer(t: TextBuffer, level: Level): Unit = {
     if (level == null || Strings.isNullOrEmpty(t.proxy.nodeAddress)) return
+
+    // Captured block entities initially register against Create's virtual
+    // render level. Move the same buffer to the real client level instead.
+    val hostLevel = t.host.getEnvironmentLevel
+    if (hostLevel != null && hostLevel != level) {
+      ClientComponentTracker.remove(hostLevel, t)
+    }
 
     // Re-applying component data during chunk/menu synchronization must not
     // leave duplicate/stale client buffer registrations behind.
@@ -569,6 +588,17 @@ object TextBuffer {
     }
 
     ClientPacketSender.sendTextBufferInit(t.proxy.nodeAddress)
+  }
+
+  def unregisterClientBuffer(t: TextBuffer, level: Level): Unit = {
+    if (level == null) return
+
+    ClientComponentTracker.remove(level, t)
+    val hostLevel = t.host.getEnvironmentLevel
+    if (hostLevel != null && hostLevel != level) {
+      ClientComponentTracker.remove(hostLevel, t)
+    }
+    clientBuffers -= t
   }
 
   abstract class Proxy {

--- a/src/main/scala/li/cil/oc/common/item/GraphicsCard.scala
+++ b/src/main/scala/li/cil/oc/common/item/GraphicsCard.scala
@@ -6,7 +6,7 @@ import net.neoforged.neoforge.common.extensions.IItemExtension
 
 
 class GraphicsCard(props: Properties, val tier: Int) extends Item(props) with traits.SimpleItem with traits.ItemTier with traits.GPULike with IItemExtension {
-  override protected def supportsDoubleSneakClick = true
+  override protected def canResetComponentIdentity = true
 
   @Deprecated
   override def getDescriptionId = super.getDescriptionId + tier

--- a/src/main/scala/li/cil/oc/common/item/GraphicsCard.scala
+++ b/src/main/scala/li/cil/oc/common/item/GraphicsCard.scala
@@ -6,6 +6,8 @@ import net.neoforged.neoforge.common.extensions.IItemExtension
 
 
 class GraphicsCard(props: Properties, val tier: Int) extends Item(props) with traits.SimpleItem with traits.ItemTier with traits.GPULike with IItemExtension {
+  override protected def supportsDoubleSneakClick = true
+
   @Deprecated
   override def getDescriptionId = super.getDescriptionId + tier
 

--- a/src/main/scala/li/cil/oc/common/item/QuadGraphicsCard.scala
+++ b/src/main/scala/li/cil/oc/common/item/QuadGraphicsCard.scala
@@ -4,4 +4,6 @@ import net.minecraft.world.item.Item
 import net.minecraft.world.item.Item.Properties
 import net.neoforged.neoforge.common.extensions.IItemExtension
 
-class QuadGraphicsCard(props: Properties) extends Item(props) with traits.SimpleItem with traits.ItemTier with IItemExtension
+class QuadGraphicsCard(props: Properties) extends Item(props) with traits.SimpleItem with traits.ItemTier with IItemExtension {
+  override protected def canResetComponentIdentity = true
+}

--- a/src/main/scala/li/cil/oc/common/item/traits/SimpleItem.scala
+++ b/src/main/scala/li/cil/oc/common/item/traits/SimpleItem.scala
@@ -74,9 +74,21 @@ trait SimpleItem extends Item with api.driver.item.UpgradeRenderer with IItemExt
   @Deprecated
   def onItemUse(stack: ItemStack, player: Player, position: BlockPosition, side: Direction, hitX: Float, hitY: Float, hitZ: Float): Boolean = false
 
+  /**
+   * Opt in to the shared double sneak-right-click gesture handled by SimpleItem.
+   * Items only need to override this flag; the timing and action live here.
+   */
+  protected def supportsDoubleSneakClick: Boolean = false
+
   @Deprecated
   override def use(world: Level, player: Player, hand: InteractionHand): InteractionResultHolder[ItemStack] =
     player.getItemInHand(hand) match {
+      case stack: ItemStack if supportsDoubleSneakClick && player.isShiftKeyDown =>
+        if (!world.isClientSide && SimpleItem.registerSneakClick(player, hand, stack.getItem, world.getGameTime)) {
+          // Dummy action only. Replace this later with the real shared behavior.
+          player.sendSystemMessage(Component.literal("Double sneak-click detected."))
+        }
+        new InteractionResultHolder(InteractionResult.sidedSuccess(world.isClientSide), stack)
       case stack: ItemStack => use(stack, world, player)
       case _ => super.use(world, player, hand)
     }
@@ -129,4 +141,18 @@ trait SimpleItem extends Item with api.driver.item.UpgradeRenderer with IItemExt
 
   @OnlyIn(Dist.CLIENT)
   override def render(matrix: PoseStack, buffer: MultiBufferSource, light: Int, stack: ItemStack, mountPoint: MountPoint, robot: Robot, pt: Float): Unit = ItemUpgradeRenderer.render(matrix, buffer, light, stack, mountPoint)
+}
+
+
+object SimpleItem {
+  private val DoubleSneakClickWindowTicks = 6L
+  private val lastSneakClicks = scala.collection.mutable.HashMap.empty[(java.util.UUID, InteractionHand, Item), Long]
+
+  private def registerSneakClick(player: Player, hand: InteractionHand, item: Item, now: Long): Boolean = synchronized {
+    val key = (player.getUUID, hand, item)
+    val isDoubleClick = lastSneakClicks.get(key).exists(last => now - last > 0 && now - last <= DoubleSneakClickWindowTicks)
+    if (isDoubleClick) lastSneakClicks.remove(key)
+    else lastSneakClicks.update(key, now)
+    isDoubleClick
+  }
 }

--- a/src/main/scala/li/cil/oc/common/item/traits/SimpleItem.scala
+++ b/src/main/scala/li/cil/oc/common/item/traits/SimpleItem.scala
@@ -1,6 +1,7 @@
 package li.cil.oc.common.item.traits
 
 import java.util
+
 import li.cil.oc.Settings
 import li.cil.oc.api
 import li.cil.oc.api.event.RobotRenderEvent.MountPoint
@@ -29,6 +30,7 @@ import li.cil.oc.common.item.data.TabletData
 import net.minecraft.core.component.DataComponents
 import net.minecraft.world.item.Item.TooltipContext
 import net.neoforged.neoforge.common.extensions.IItemExtension
+import li.cil.oc.common.datacomponents.OCComponents
 
 trait SimpleItem extends Item with api.driver.item.UpgradeRenderer with IItemExtension {
   def createItemStack(amount: Int = 1) = new ItemStack(this, amount)
@@ -78,23 +80,32 @@ trait SimpleItem extends Item with api.driver.item.UpgradeRenderer with IItemExt
    * Opt in to the shared double sneak-right-click gesture handled by SimpleItem.
    * Items only need to override this flag; the timing and action live here.
    */
-  protected def supportsDoubleSneakClick: Boolean = false
+  protected def canResetComponentIdentity: Boolean = false
 
   @Deprecated
   override def use(world: Level, player: Player, hand: InteractionHand): InteractionResultHolder[ItemStack] =
     player.getItemInHand(hand) match {
-      case stack: ItemStack if supportsDoubleSneakClick && player.isShiftKeyDown =>
-        if (!world.isClientSide && SimpleItem.registerSneakClick(player, hand, stack.getItem, world.getGameTime)) {
-          // Dummy action only. Replace this later with the real shared behavior.
-          player.sendSystemMessage(Component.literal("Double sneak-click detected."))
+      case stack: ItemStack if canResetComponentIdentity && player.isShiftKeyDown =>
+        if (!world.isClientSide) {
+          if (SimpleItem.registerSneakClick(player, hand, stack.getItem, world.getGameTime)) {
+            stack.remove(OCComponents.ADDRESS.get())
+            stack.remove(OCComponents.VISIBILITY.get())
+
+            player.displayClientMessage(Component.literal("Component UUID reset."), true)
+          }
+          else {
+            player.displayClientMessage(Component.literal("Double click quickly to reset"), true)
+          }
         }
         new InteractionResultHolder(InteractionResult.sidedSuccess(world.isClientSide), stack)
+
       case stack: ItemStack => use(stack, world, player)
       case _ => super.use(world, player, hand)
     }
 
   @Deprecated
-  def use(stack: ItemStack, level: Level, player: Player): InteractionResultHolder[ItemStack] = new InteractionResultHolder(InteractionResult.PASS, stack)
+  def use(stack: ItemStack, level: Level, player: Player): InteractionResultHolder[ItemStack] =
+    new InteractionResultHolder(InteractionResult.PASS, stack)
 
   protected def tierFromDriver(stack: ItemStack): Int =
     api.Driver.driverFor(stack) match {
@@ -137,12 +148,13 @@ trait SimpleItem extends Item with api.driver.item.UpgradeRenderer with IItemExt
 
   // ----------------------------------------------------------------------- //
 
-  override def computePreferredMountPoint(stack: ItemStack, robot: Robot, availableMountPoints: util.Set[String]): String = ItemUpgradeRenderer.preferredMountPoint(stack, availableMountPoints)
+  override def computePreferredMountPoint(stack: ItemStack, robot: Robot, availableMountPoints: util.Set[String]): String =
+    ItemUpgradeRenderer.preferredMountPoint(stack, availableMountPoints)
 
   @OnlyIn(Dist.CLIENT)
-  override def render(matrix: PoseStack, buffer: MultiBufferSource, light: Int, stack: ItemStack, mountPoint: MountPoint, robot: Robot, pt: Float): Unit = ItemUpgradeRenderer.render(matrix, buffer, light, stack, mountPoint)
+  override def render(matrix: PoseStack, buffer: MultiBufferSource, light: Int, stack: ItemStack, mountPoint: MountPoint, robot: Robot, pt: Float): Unit =
+    ItemUpgradeRenderer.render(matrix, buffer, light, stack, mountPoint)
 }
-
 
 object SimpleItem {
   private val DoubleSneakClickWindowTicks = 6L
@@ -151,8 +163,10 @@ object SimpleItem {
   private def registerSneakClick(player: Player, hand: InteractionHand, item: Item, now: Long): Boolean = synchronized {
     val key = (player.getUUID, hand, item)
     val isDoubleClick = lastSneakClicks.get(key).exists(last => now - last > 0 && now - last <= DoubleSneakClickWindowTicks)
+
     if (isDoubleClick) lastSneakClicks.remove(key)
     else lastSneakClicks.update(key, now)
+
     isDoubleClick
   }
 }

--- a/src/main/scala/li/cil/oc/integration/create/CreateContraptionTransformers.java
+++ b/src/main/scala/li/cil/oc/integration/create/CreateContraptionTransformers.java
@@ -6,6 +6,7 @@ import com.simibubi.create.api.behaviour.interaction.MovingInteractionBehaviour;
 import com.simibubi.create.content.contraptions.AbstractContraptionEntity;
 import com.simibubi.create.content.contraptions.behaviour.MovementContext;
 import com.simibubi.create.content.contraptions.StructureTransform;
+import com.simibubi.create.content.trains.entity.CarriageContraptionEntity;
 import li.cil.oc.api.Network;
 import li.cil.oc.common.block.Case;
 import li.cil.oc.common.block.Keyboard;
@@ -243,6 +244,11 @@ final class CreateContraptionTransformers {
         // The fake BE is not in Level.blockEntities, so the normal neighbor scan
         // cannot find it. A private network still lets its machine and cards run.
         Network.joinNewNetwork(environment.node());
+        if (environment instanceof Computer computer
+                && context.contraption.entity instanceof CarriageContraptionEntity carriageEntity
+                && carriageEntity.getCarriage() != null) {
+            CreateTrainEnvironment.attach(computer, carriageEntity.getCarriage().train, context.world);
+        }
         return environment;
     }
 
@@ -301,6 +307,7 @@ final class CreateContraptionTransformers {
         // component_removed while the remaining actors disappear.
         for (var actor : context.contraption.getActors()) {
             if (actor.right.temporaryData instanceof Computer computer) {
+                CreateTrainEnvironment.detach(computer);
                 computer.disposeMoving();
                 actor.right.temporaryData = null;
             }

--- a/src/main/scala/li/cil/oc/integration/create/CreateContraptionTransformers.java
+++ b/src/main/scala/li/cil/oc/integration/create/CreateContraptionTransformers.java
@@ -8,11 +8,8 @@ import com.simibubi.create.content.contraptions.behaviour.MovementContext;
 import com.simibubi.create.content.contraptions.StructureTransform;
 import li.cil.oc.api.Network;
 import li.cil.oc.common.block.Case;
-import li.cil.oc.common.block.Cable;
 import li.cil.oc.common.block.Keyboard;
 import li.cil.oc.common.block.Microcontroller;
-import li.cil.oc.common.block.Redstone;
-import li.cil.oc.common.block.RobotProxy;
 import li.cil.oc.common.block.Screen;
 import li.cil.oc.common.block.SimpleBlock;
 import li.cil.oc.common.blockentity.BlockEntityTypes;
@@ -58,13 +55,12 @@ final class CreateContraptionTransformers {
             if (block instanceof SimpleBlock) {
                 MovedBlockTransformerRegistries.BLOCK_TRANSFORMERS.register(
                         block, CreateContraptionTransformers::transformBlock);
-            }
-            if (block instanceof Case || block instanceof Microcontroller || block instanceof RobotProxy
-                    || block instanceof Cable || block instanceof Redstone || block instanceof Screen
-                    || block instanceof Keyboard) {
-                // This is the part where the computer gets dragged into Create's actor system.
-                // Maybe this works.
-                MovementBehaviour.REGISTRY.register(block, OC_MOVEMENT);
+                if (block.defaultBlockState().hasBlockEntity()) {
+                    // Any OC block entity can be an external component. Give it a
+                    // live moving host instead of only supporting the handful of
+                    // blocks that happened to be used by the first test rig.
+                    MovementBehaviour.REGISTRY.register(block, OC_MOVEMENT);
+                }
             }
             if (block instanceof Case || block instanceof Microcontroller || block instanceof Screen
                     || block instanceof Keyboard) {
@@ -97,12 +93,19 @@ final class CreateContraptionTransformers {
         @Override
         public void tick(final MovementContext context) {
             if (context.world.isClientSide) {
+                registerMovingScreen(context);
                 return;
             }
 
             Environment environment = movingEnvironment(context);
             if (environment == null) {
-                return;
+                // Train carriages can deserialize their actor contexts without
+                // temporaryData. Rebuild OC's off-world block entity on demand.
+                environment = makeEnvironment(context);
+                context.temporaryData = environment;
+                if (environment == null) {
+                    return;
+                }
             }
 
             // The position is the center of the actor block. OC wants that
@@ -138,12 +141,7 @@ final class CreateContraptionTransformers {
                 return;
             }
 
-            saveEnvironment(context);
-            Environment environment = movingEnvironment(context);
-            if (environment != null) {
-                environment.disposeMoving();
-            }
-            context.temporaryData = null;
+            stopMovingEnvironments(context);
         }
 
         @Override
@@ -227,12 +225,15 @@ final class CreateContraptionTransformers {
         // position while loadWithComponents reads that file. If we let it use
         // localPos here, it finds nothing and builds a blank T1 buffer instead.
         BlockPos originalPos = context.localPos.offset(context.contraption.anchor);
-        environment.beginMoving(
-                context.world,
-                new Vec3(
+        Vec3 savedPosition = context.position != null
+                ? context.position
+                : new Vec3(
                         originalPos.getX() + 0.5,
                         originalPos.getY() + 0.5,
-                        originalPos.getZ() + 0.5),
+                        originalPos.getZ() + 0.5);
+        environment.beginMoving(
+                context.world,
+                savedPosition,
                 context.rotation,
                 context.state);
         if (context.blockEntityData != null) {
@@ -261,10 +262,55 @@ final class CreateContraptionTransformers {
         }
     }
 
+    private static void registerMovingScreen(final MovementContext context) {
+        if (context.contraption == null || context.contraption.entity == null) {
+            return;
+        }
+
+        BlockEntity renderEntity = context.contraption.getOrCreateClientContraptionLazy()
+                .getBlockEntity(context.localPos);
+        if (renderEntity instanceof li.cil.oc.common.blockentity.Screen screen) {
+            screen.registerMovingClientBuffer(context.contraption.entity.level());
+        }
+    }
+
     private static void saveEnvironment(final MovementContext context) {
         Environment environment = movingEnvironment(context);
         if (environment != null && context.blockEntityData != null) {
             environment.saveMovingState(context.blockEntityData, context.world.registryAccess());
+        }
+    }
+
+    private static void stopMovingEnvironments(final MovementContext context) {
+        if (movingEnvironment(context) == null || context.contraption == null) {
+            return;
+        }
+
+        // Create stops actors one at a time. If the floppy drive happens to go
+        // first, OpenOS gets told its boot filesystem vanished before Create
+        // reaches the computer. Save the entire OC network while it still
+        // exists, then tear it down ourselves in an order that cannot do that.
+        for (var actor : context.contraption.getActors()) {
+            if (actor.right.temporaryData instanceof Environment) {
+                saveEnvironment(actor.right);
+            }
+        }
+
+        // Close every VM before removing any external component host. Their
+        // state is safely in NBT now, and a dead listener cannot queue a fake
+        // component_removed while the remaining actors disappear.
+        for (var actor : context.contraption.getActors()) {
+            if (actor.right.temporaryData instanceof Computer computer) {
+                computer.disposeMoving();
+                actor.right.temporaryData = null;
+            }
+        }
+
+        for (var actor : context.contraption.getActors()) {
+            if (actor.right.temporaryData instanceof Environment environment) {
+                environment.disposeMoving();
+                actor.right.temporaryData = null;
+            }
         }
     }
 

--- a/src/main/scala/li/cil/oc/integration/create/CreateContraptionTransformers.java
+++ b/src/main/scala/li/cil/oc/integration/create/CreateContraptionTransformers.java
@@ -1,18 +1,45 @@
 package li.cil.oc.integration.create;
 
 import com.simibubi.create.api.contraption.transformable.MovedBlockTransformerRegistries;
+import com.simibubi.create.api.behaviour.movement.MovementBehaviour;
+import com.simibubi.create.api.behaviour.interaction.MovingInteractionBehaviour;
+import com.simibubi.create.content.contraptions.AbstractContraptionEntity;
+import com.simibubi.create.content.contraptions.behaviour.MovementContext;
 import com.simibubi.create.content.contraptions.StructureTransform;
+import li.cil.oc.api.Network;
+import li.cil.oc.common.block.Case;
+import li.cil.oc.common.block.Cable;
+import li.cil.oc.common.block.Keyboard;
+import li.cil.oc.common.block.Microcontroller;
+import li.cil.oc.common.block.Redstone;
+import li.cil.oc.common.block.RobotProxy;
+import li.cil.oc.common.block.Screen;
 import li.cil.oc.common.block.SimpleBlock;
 import li.cil.oc.common.blockentity.BlockEntityTypes;
+import li.cil.oc.common.blockentity.traits.Computer;
+import li.cil.oc.common.blockentity.traits.Environment;
+import li.cil.oc.common.blockentity.traits.RedstoneAware;
 import li.cil.oc.common.blockentity.traits.Rotatable;
+import li.cil.oc.common.blockentity.traits.Tickable;
+import li.cil.oc.common.menu.MenuTypes;
+import li.cil.oc.util.BlockPosHelper;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.InteractionHand;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.EntityBlock;
+import net.minecraft.world.level.block.Mirror;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.block.state.properties.Property;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate.StructureBlockInfo;
+import net.minecraft.world.phys.Vec3;
 
 /** Create transformations for OC blocks. This got a bit out of hand. */
 final class CreateContraptionTransformers {
@@ -32,6 +59,19 @@ final class CreateContraptionTransformers {
                 MovedBlockTransformerRegistries.BLOCK_TRANSFORMERS.register(
                         block, CreateContraptionTransformers::transformBlock);
             }
+            if (block instanceof Case || block instanceof Microcontroller || block instanceof RobotProxy
+                    || block instanceof Cable || block instanceof Redstone || block instanceof Screen
+                    || block instanceof Keyboard) {
+                // This is the part where the computer gets dragged into Create's actor system.
+                // Maybe this works.
+                MovementBehaviour.REGISTRY.register(block, OC_MOVEMENT);
+            }
+            if (block instanceof Case || block instanceof Microcontroller || block instanceof Screen
+                    || block instanceof Keyboard) {
+                // Chests get this for free. OC needs a special invitation.
+                // FUCK YOU MINECRAFT! Apparently moving blocks have a second click system.
+                MovingInteractionBehaviour.REGISTRY.register(block, OC_INTERACTION);
+            }
         }
 
         registerBlockEntity(BlockEntityTypes.HOLOGRAM.get());
@@ -42,6 +82,238 @@ final class CreateContraptionTransformers {
     private static void registerBlockEntity(final BlockEntityType<?> type) {
         MovedBlockTransformerRegistries.BLOCK_ENTITY_TRANSFORMERS.register(
                 type, CreateContraptionTransformers::transformBlockEntity);
+    }
+
+    private static final MovementBehaviour OC_MOVEMENT = new MovementBehaviour() {
+        @Override
+        public void startMoving(final MovementContext context) {
+            // Create does not keep a live BlockEntity around while it is moving.
+            // So we make one. This sounds worse when written down.
+            if (!context.world.isClientSide) {
+                context.temporaryData = makeEnvironment(context);
+            }
+        }
+
+        @Override
+        public void tick(final MovementContext context) {
+            if (context.world.isClientSide) {
+                return;
+            }
+
+            Environment environment = movingEnvironment(context);
+            if (environment == null) {
+                return;
+            }
+
+            // The position is the center of the actor block. OC wants that
+            // position for wireless range, sounds, events, and packet logs.
+            Vec3 position = context.position;
+            if (position == null) {
+                position = new Vec3(
+                        context.localPos.getX() + 0.5,
+                        context.localPos.getY() + 0.5,
+                        context.localPos.getZ() + 0.5);
+            }
+            environment.updateMovingPosition(position, context.rotation, context.state);
+            if (environment instanceof Computer computer) {
+                computer.tickMoving();
+            } else if (environment instanceof Tickable tickable) {
+                tickable.tick();
+            }
+
+            // Vanilla redstone is not ticking inside Create's little magic box.
+            // So if the OC output is next to a captured lamp, fake the one bit
+            // of redstone simulation we actually need. Hmmm. Like this?
+            syncMovingLamp(context, environment);
+
+            // Hmmm. The real cable network is also off-world. Reconnect the
+            // fake nodes whenever both ends of an OC connection exist.
+            connectMovingNeighbors(context, environment);
+        }
+
+        @Override
+        public void stopMoving(final MovementContext context) {
+            if (context.world.isClientSide) {
+                unregisterMovingScreen(context);
+                return;
+            }
+
+            saveEnvironment(context);
+            Environment environment = movingEnvironment(context);
+            if (environment != null) {
+                environment.disposeMoving();
+            }
+            context.temporaryData = null;
+        }
+
+        @Override
+        public void writeExtraData(final MovementContext context) {
+            // Hmmm. Like this? Create may save a running contraption before it stops.
+            saveEnvironment(context);
+        }
+    };
+
+    private static final MovingInteractionBehaviour OC_INTERACTION = new MovingInteractionBehaviour() {
+        @Override
+        public boolean handlePlayerInteraction(final Player player, final InteractionHand hand,
+                                               final BlockPos localPos,
+                                               final AbstractContraptionEntity contraptionEntity) {
+            if (contraptionEntity.level().isClientSide) {
+                // Case menus are opened by the server. Screens are the weird
+                // exception: their terminal GUI is deliberately client-only.
+                BlockEntity renderEntity = contraptionEntity.getContraption()
+                        .getOrCreateClientContraptionLazy().getBlockEntity(localPos);
+                StructureBlockInfo capturedInfo = contraptionEntity.getContraption().getBlocks().get(localPos);
+                if (renderEntity == null || capturedInfo == null) {
+                    return true;
+                }
+                BlockState capturedState = capturedInfo.state();
+                if (renderEntity instanceof li.cil.oc.common.blockentity.Screen screen
+                        && capturedState.getBlock() instanceof Screen screenBlock) {
+                    screen.registerMovingClientBuffer(contraptionEntity.level());
+                    screenBlock.rightClick(renderEntity.getLevel(), localPos, player, hand,
+                            player.getItemInHand(hand), screen.facing(), 0.5f, 0.5f, 0.5f, true);
+                } else if (renderEntity instanceof li.cil.oc.common.blockentity.Keyboard keyboard
+                        && capturedState.getBlock() instanceof Keyboard keyboardBlock) {
+                    keyboardBlock.localOnBlockActivated(renderEntity.getLevel(), localPos, player, hand,
+                            player.getItemInHand(hand), keyboard.facing(), 0.5f, 0.5f, 0.5f);
+                }
+                return true;
+            }
+
+            if (!(player instanceof ServerPlayer serverPlayer)) {
+                return false;
+            }
+
+            var actor = contraptionEntity.getContraption().getActorAt(localPos);
+            if (actor == null || actor.right == null
+                    || !(actor.right.temporaryData instanceof Environment environment)) {
+                return false;
+            }
+
+            if (environment instanceof li.cil.oc.common.blockentity.Case computer
+                    && computer.stillValid(player)) {
+                MenuTypes.openCaseGui(serverPlayer, computer);
+                return true;
+            }
+
+            if (environment instanceof li.cil.oc.common.blockentity.Microcontroller microcontroller) {
+                if (microcontroller.machine().isRunning()) {
+                    microcontroller.machine().stop();
+                } else {
+                    microcontroller.machine().start();
+                }
+                return true;
+            }
+
+            return false;
+        }
+    };
+
+    private static Environment makeEnvironment(final MovementContext context) {
+        if (!(context.state.getBlock() instanceof EntityBlock entityBlock)) {
+            return null;
+        }
+
+        BlockEntity blockEntity = entityBlock.newBlockEntity(context.localPos, context.state);
+        if (!(blockEntity instanceof Environment environment)) {
+            return null;
+        }
+
+        blockEntity.setLevel(context.world);
+
+        // Screen buffers live in SaveHandler files named by their world chunk.
+        // Make the fake block entity look like it is still at its pre-assembly
+        // position while loadWithComponents reads that file. If we let it use
+        // localPos here, it finds nothing and builds a blank T1 buffer instead.
+        BlockPos originalPos = context.localPos.offset(context.contraption.anchor);
+        environment.beginMoving(
+                context.world,
+                new Vec3(
+                        originalPos.getX() + 0.5,
+                        originalPos.getY() + 0.5,
+                        originalPos.getZ() + 0.5),
+                context.rotation,
+                context.state);
+        if (context.blockEntityData != null) {
+            blockEntity.loadWithComponents(context.blockEntityData, context.world.registryAccess());
+        }
+
+        // The fake BE is not in Level.blockEntities, so the normal neighbor scan
+        // cannot find it. A private network still lets its machine and cards run.
+        Network.joinNewNetwork(environment.node());
+        return environment;
+    }
+
+    private static Environment movingEnvironment(final MovementContext context) {
+        return context.temporaryData instanceof Environment environment ? environment : null;
+    }
+
+    private static void unregisterMovingScreen(final MovementContext context) {
+        if (context.contraption == null || context.contraption.entity == null) {
+            return;
+        }
+
+        BlockEntity renderEntity = context.contraption.getOrCreateClientContraptionLazy()
+                .getBlockEntity(context.localPos);
+        if (renderEntity instanceof li.cil.oc.common.blockentity.Screen screen) {
+            screen.unregisterMovingClientBuffer();
+        }
+    }
+
+    private static void saveEnvironment(final MovementContext context) {
+        Environment environment = movingEnvironment(context);
+        if (environment != null && context.blockEntityData != null) {
+            environment.saveMovingState(context.blockEntityData, context.world.registryAccess());
+        }
+    }
+
+    private static void connectMovingNeighbors(final MovementContext context, final Environment environment) {
+        for (Direction side : Direction.values()) {
+            BlockPos neighborPos = BlockPosHelper.relative(context.localPos, side);
+            for (var actor : context.contraption.getActors()) {
+                if (!neighborPos.equals(actor.left.pos())) {
+                    continue;
+                }
+                Environment neighbor = actor.right.temporaryData instanceof Environment other ? other : null;
+                if (neighbor != null && neighbor.node() != null && environment.node() != null) {
+                    environment.node().connect(neighbor.node());
+                }
+            }
+        }
+    }
+
+    private static void syncMovingLamp(final MovementContext context, final Environment environment) {
+        if (!(environment instanceof RedstoneAware redstone)
+                || context.contraption == null
+                || context.contraption.entity == null) {
+            return;
+        }
+
+        for (Direction localSide : Direction.values()) {
+            Direction worldSide = redstone.toGlobal(localSide);
+            if (worldSide == null) {
+                continue;
+            }
+
+            BlockPos lampPos = BlockPosHelper.relative(context.localPos, localSide);
+            StructureBlockInfo lampInfo = context.contraption.getBlocks().get(lampPos);
+            if (lampInfo == null || !lampInfo.state().is(Blocks.REDSTONE_LAMP)) {
+                continue;
+            }
+
+            boolean lit = redstone.getOutput(worldSide) > 0;
+            boolean alreadyLit = lampInfo.state().getValue(BlockStateProperties.LIT);
+            if (lit == alreadyLit) {
+                continue;
+            }
+
+            // FUCK YOU MINECRAFT! A moving lamp is not really a lamp right now.
+            BlockState newState = lampInfo.state().setValue(BlockStateProperties.LIT, lit);
+            context.contraption.entity.setBlock(
+                    lampPos,
+                    new StructureBlockInfo(lampInfo.pos(), newState, lampInfo.nbt()));
+        }
     }
 
     static BlockState transformBlock(final BlockState state, final StructureTransform transform) {

--- a/src/main/scala/li/cil/oc/integration/create/CreateContraptionTransformers.java
+++ b/src/main/scala/li/cil/oc/integration/create/CreateContraptionTransformers.java
@@ -1,0 +1,173 @@
+package li.cil.oc.integration.create;
+
+import com.simibubi.create.api.contraption.transformable.MovedBlockTransformerRegistries;
+import com.simibubi.create.content.contraptions.StructureTransform;
+import li.cil.oc.common.block.SimpleBlock;
+import li.cil.oc.common.blockentity.BlockEntityTypes;
+import li.cil.oc.common.blockentity.traits.Rotatable;
+import net.minecraft.core.Direction;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.Property;
+
+/** Create transformations for OC blocks. This got a bit out of hand. */
+final class CreateContraptionTransformers {
+    private static final String PITCH = "pitch";
+    private static final String YAW = "yaw";
+    private static final String FACING = "facing";
+    private static final String MOUNT = "mount";
+
+    private CreateContraptionTransformers() {
+    }
+
+    static void register() {
+        // I tried to make a list of these. The registry loop was less typing.
+        // Maybe this works.
+        for (Block block : BuiltInRegistries.BLOCK) {
+            if (block instanceof SimpleBlock) {
+                MovedBlockTransformerRegistries.BLOCK_TRANSFORMERS.register(
+                        block, CreateContraptionTransformers::transformBlock);
+            }
+        }
+
+        registerBlockEntity(BlockEntityTypes.HOLOGRAM.get());
+        registerBlockEntity(BlockEntityTypes.PRINT.get());
+        registerBlockEntity(BlockEntityTypes.ROBOT.get());
+    }
+
+    private static void registerBlockEntity(final BlockEntityType<?> type) {
+        MovedBlockTransformerRegistries.BLOCK_ENTITY_TRANSFORMERS.register(
+                type, CreateContraptionTransformers::transformBlockEntity);
+    }
+
+    static BlockState transformBlock(final BlockState state, final StructureTransform transform) {
+        Direction pitch = getDirection(state, PITCH);
+        Direction yaw = getDirection(state, YAW);
+        if (pitch != null && yaw != null) {
+            return transformPitchAndYaw(state, pitch, yaw, transform);
+        }
+
+        Direction facing = getDirection(state, FACING);
+        if (facing != null) {
+            Direction transformed = transformDirection(facing, transform);
+            if (hasDirection(state, FACING, transformed)) {
+                return setDirection(state, FACING, transformed);
+            }
+        }
+
+        Direction mount = getDirection(state, MOUNT);
+        if (mount != null) {
+            Direction transformed = transformDirection(mount, transform);
+            if (hasDirection(state, MOUNT, transformed)) {
+                return setDirection(state, MOUNT, transformed);
+            }
+        }
+
+        return state;
+    }
+
+    private static BlockState transformPitchAndYaw(final BlockState state, final Direction pitch,
+                                                    final Direction yaw, final StructureTransform transform) {
+        // Pitch is either actually pitch or NORTH pretending not to be pitch.
+        // Hmmm. Like this?
+        Direction forward = yaw;
+        Direction up = Direction.UP;
+        if (pitch.getAxis().isVertical()) {
+            forward = pitch;
+            up = yaw;
+        }
+        forward = transformDirection(forward, transform);
+        up = transformDirection(up, transform);
+
+        if (forward.getAxis().isVertical()) {
+            BlockState result = setDirection(state, PITCH, forward);
+            if (hasDirection(result, YAW, up)) {
+                result = setDirection(result, YAW, up);
+            }
+            return result;
+        }
+
+        // PropertyRotatable.Pitch only allows UP, DOWN, or NORTH. Horizontal
+        // orientation lives in Yaw, so NORTH is the "no pitch" sentinel here.
+        // FUCK YOU MINECRAFT! Why is NORTH the "not really pitch" direction?
+        BlockState result = setDirection(state, PITCH, Direction.NORTH);
+        if (hasDirection(result, YAW, forward)) {
+            result = setDirection(result, YAW, forward);
+        }
+        return result;
+    }
+
+    private static Direction transformDirection(final Direction direction, final StructureTransform transform) {
+        Direction result = direction;
+        if (transform.mirror != null && transform.mirror != Mirror.NONE) {
+            result = transform.mirrorFacing(result);
+        }
+        // Create calls this with Rotation.NONE sometimes, which is fine.
+        if (transform.rotation != null && transform.rotationAxis != null
+                && transform.rotation.ordinal() != 0) {
+            result = transform.rotateFacing(result);
+        }
+        return result;
+    }
+
+    private static void transformBlockEntity(final BlockEntity blockEntity, final StructureTransform transform) {
+        if (!(blockEntity instanceof Rotatable rotatable)) {
+            return;
+        }
+
+        Direction oldPitch = rotatable.pitch();
+        Direction oldYaw = rotatable.yaw();
+        Direction forward = oldYaw;
+        Direction up = Direction.UP;
+        if (oldPitch.getAxis().isVertical()) {
+            forward = oldPitch;
+            up = oldYaw;
+        }
+        forward = transformDirection(forward, transform);
+        up = transformDirection(up, transform);
+
+        // There is probably a nicer way to do this. This is the way that is
+        // least likely to make the old block orientation code angry.
+        if (forward.getAxis().isVertical()) {
+            rotatable.setFromPitchAndYaw(forward,
+                    up.getAxis().isHorizontal() ? up : oldYaw);
+        } else {
+            rotatable.setFromPitchAndYaw(Direction.NORTH, forward);
+        }
+    }
+
+    private static Direction getDirection(final BlockState state, final String name) {
+        final Property<?> property = findProperty(state, name);
+        if (property == null) {
+            return null;
+        }
+        return state.getValue(directionProperty(property));
+    }
+
+    private static boolean hasDirection(final BlockState state, final String name, final Direction value) {
+        final Property<?> property = findProperty(state, name);
+        return property != null && property.getPossibleValues().contains(value);
+    }
+
+    private static BlockState setDirection(final BlockState state, final String name, final Direction value) {
+        return state.setValue(directionProperty(findProperty(state, name)), value);
+    }
+
+    private static Property<?> findProperty(final BlockState state, final String name) {
+        for (Property<?> property : state.getProperties()) {
+            if (property.getName().equals(name)) {
+                return property;
+            }
+        }
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Property<Direction> directionProperty(final Property<?> property) {
+        return (Property<Direction>) property;
+    }
+}

--- a/src/main/scala/li/cil/oc/integration/create/ModCreate.scala
+++ b/src/main/scala/li/cil/oc/integration/create/ModCreate.scala
@@ -6,6 +6,7 @@ object ModCreate extends ModProxy {
   override def getMod = Mods.Create
 
   override def initialize(): Unit = {
+    CreateContraptionTransformers.register()
     CreateDrivers.register()
   }
 }

--- a/src/main/scala/li/cil/oc/server/PacketHandler.scala
+++ b/src/main/scala/li/cil/oc/server/PacketHandler.scala
@@ -43,7 +43,9 @@ object PacketHandler extends CommonPacketHandler {
   private def canInteractWith(buffer: api.internal.TextBuffer, player: Player): Boolean = buffer match {
     case textBuffer: TextBuffer => textBuffer.host match {
       case screen: Screen => screen.screens.exists(part =>
-        player.distanceToSqr(part.x + 0.5, part.y + 0.5, part.z + 0.5) <= 64)
+        // A Create contraption keeps the fake Screen at its local block position,
+        // but EnvironmentHost exposes the real moving position for interaction.
+        player.distanceToSqr(part.xPosition, part.yPosition, part.zPosition) <= 64)
       case remote: RemoteTerminalHost => remote.isBufferUsable(buffer, player)
       case _ => true
     }

--- a/src/main/scala/li/cil/oc/server/machine/Machine.scala
+++ b/src/main/scala/li/cil/oc/server/machine/Machine.scala
@@ -88,6 +88,12 @@ class Machine(val host: MachineHost) extends AbstractManagedEnvironment with mac
 
   private val addedComponents = mutable.Set.empty[Component]
 
+  // A Create contraption places its captured block entities one at a time.
+  // Keep already-known components alive while those tiny temporary networks
+  // split and merge, then reconcile them against the finished structure.
+  private var componentRestoreGrace = 0
+  private val deferredRemovedComponents = mutable.Map.empty[String, String]
+
   private val _users = mutable.Set.empty[String]
 
   private val signals = mutable.Queue.empty[Machine.Signal]
@@ -532,6 +538,7 @@ class Machine(val host: MachineHost) extends AbstractManagedEnvironment with mac
     // but that wouldn't trigger a connect message anymore due to the higher
     // reachability).
     processAddedComponents()
+    tickComponentRestoreGrace()
 
     // Component overflow check, crash if too many components are connected, to
     // avoid confusion on the user's side due to components not showing up.
@@ -706,6 +713,7 @@ class Machine(val host: MachineHost) extends AbstractManagedEnvironment with mac
   // ----------------------------------------------------------------------- //
 
   def addComponent(component: Component): Unit = {
+    deferredRemovedComponents -= component.address
     if (!_components.contains(component.address)) {
       addedComponents += component
     }
@@ -713,10 +721,41 @@ class Machine(val host: MachineHost) extends AbstractManagedEnvironment with mac
 
   def removeComponent(component: Component): Unit = {
     if (_components.contains(component.address)) {
-      _components.synchronized(_components -= component.address)
-      signal("component_removed", component.address, component.name)
+      if (componentRestoreGrace > 0) {
+        deferredRemovedComponents(component.address) = component.name
+      }
+      else {
+        _components.synchronized(_components -= component.address)
+        signal("component_removed", component.address, component.name)
+      }
     }
     addedComponents -= component
+  }
+
+  /** Suppress transient component removal events while Create restores blocks. */
+  def beginComponentRestoreGrace(ticks: Int): Unit = {
+    if (isRunning) {
+      componentRestoreGrace = math.max(componentRestoreGrace, ticks)
+      pause(componentRestoreGrace / 20.0)
+    }
+  }
+
+  private def tickComponentRestoreGrace(): Unit = if (componentRestoreGrace > 0) {
+    componentRestoreGrace -= 1
+    if (componentRestoreGrace == 0) {
+      val network = node.network
+      for ((address, name) <- deferredRemovedComponents) {
+        val restored = network != null && (network.node(address) match {
+          case component: Component => component.name == name
+          case _ => false
+        })
+        if (!restored && _components.contains(address)) {
+          _components.synchronized(_components -= address)
+          signal("component_removed", address, name)
+        }
+      }
+      deferredRemovedComponents.clear()
+    }
   }
 
   private def processAddedComponents(): Unit = {
@@ -736,6 +775,8 @@ class Machine(val host: MachineHost) extends AbstractManagedEnvironment with mac
   }
 
   private def verifyComponents(): Unit = {
+    if (componentRestoreGrace > 0) return
+
     val invalid = mutable.Set.empty[String]
     for ((address, name) <- _components) {
       node.network.node(address) match {
@@ -980,6 +1021,8 @@ class Machine(val host: MachineHost) extends AbstractManagedEnvironment with mac
       this.synchronized(state.synchronized {
         state.clear()
         state.push(Machine.State.Stopped)
+        componentRestoreGrace = 0
+        deferredRemovedComponents.clear()
         Option(architecture).foreach(_.close())
         signals.clear()
         uptime = 0


### PR DESCRIPTION
## Summary

Adds support for running OpenComputers: Rebooted computers on Create contraptions and trains, introduces the first pass of Create train integration, and adds sneak-double-click handling for clearing stored UUIDs from supported items.

Computers can now remain operational while attached to moving Create contraptions, including maintaining wireless communication while in motion.

Train support in this PR is intentionally a **first pass**. It establishes the initial integration and component support, but does not attempt to expose the entirety of Create's train functionality yet.

## Changes

- Add support for OC:R computers running while part of Create contraptions.
- Add support for computers mounted on Create trains.
- Add the initial Create Train component/API for interacting with Create trains from Lua.
- Preserve computer operation and networking while contraptions are moving.
- Add sneak-double-click handling to clear stored UUIDs from supported OC:R items.
- Complete the underlying double-sneak-click handling system.
- Fix a `java.lang.NoClassDefFoundError` related to Create integration.
- Fix fan sound effects being audible globally instead of locally.  (there is still another bug for this, fixed in another branch)

## Train Support Status

Create train integration in this PR should be considered a **first-pass implementation**.

The primary goal is to establish working train-mounted computers and the initial OC:R/Create integration layer. The current train component exposes a starting set of functionality, but it is not intended to be a complete train API.

Additional train control, rail/network awareness, and component functionality can be expanded in future updates.

## Testing

Tested with computers mounted directly on moving Create contraptions and trains.

Confirmed that:

- OpenOS continues running while the contraption is moving.
- Wireless cards can transmit and receive messages while moving.
- Computers can continue communicating with stationary OC:R systems during movement.
- Train-mounted computers remain operational during travel.
- The initial Create Train component is accessible from OC:R.
- Supported items can have their stored UUID cleared using the sneak-double-click action.

This establishes the foundation for computer-controlled Create trains, onboard computer systems, and wireless communication between moving and stationary OC:R computers.