### PR TITLE
Opt a bunch of peripheral cards into the UUID cleaning system

### DIFF
--- a/src/main/scala/li/cil/oc/common/item/APU.scala
+++ b/src/main/scala/li/cil/oc/common/item/APU.scala
@@ -23,4 +23,6 @@ class APU(props: Properties, val tier: Int) extends Item(props) with traits.Simp
   override protected def tooltipData: Seq[Any] = {
     super[CPULike].tooltipData ++ super[GPULike].tooltipData
   }
+
+  override protected def canResetComponentIdentity: Boolean = true
 }

--- a/src/main/scala/li/cil/oc/common/item/AudioCard.scala
+++ b/src/main/scala/li/cil/oc/common/item/AudioCard.scala
@@ -5,4 +5,6 @@ import net.minecraft.world.item.Item.Properties
 import net.neoforged.neoforge.common.extensions.IItemExtension
 
 
-class AudioCard(props: Properties) extends Item(props) with traits.SimpleItem with IItemExtension
+class AudioCard(props: Properties) extends Item(props) with traits.SimpleItem with IItemExtension {
+  override protected def canResetComponentIdentity: Boolean = true
+}

--- a/src/main/scala/li/cil/oc/common/item/CPU.scala
+++ b/src/main/scala/li/cil/oc/common/item/CPU.scala
@@ -13,4 +13,6 @@ class CPU(props: Properties, val tier: Int) extends Item(props) with traits.Simp
   override def cpuTier = tier
 
   override protected def tooltipName = Option(unlocalizedName)
+
+  override protected def canResetComponentIdentity: Boolean = true
 }

--- a/src/main/scala/li/cil/oc/common/item/DataCard.scala
+++ b/src/main/scala/li/cil/oc/common/item/DataCard.scala
@@ -8,4 +8,6 @@ import net.neoforged.neoforge.common.extensions.IItemExtension
 class DataCard(props: Properties, val tier: Int) extends Item(props) with traits.SimpleItem with traits.ItemTier with IItemExtension {
   @Deprecated
   override def getDescriptionId = super.getDescriptionId + tier
+
+  override protected def canResetComponentIdentity: Boolean = true
 }

--- a/src/main/scala/li/cil/oc/common/item/DebugCard.scala
+++ b/src/main/scala/li/cil/oc/common/item/DebugCard.scala
@@ -18,6 +18,8 @@ import net.minecraft.Util
 import net.neoforged.neoforge.common.extensions.IItemExtension
 
 class DebugCard(props: Properties) extends Item(props) with traits.SimpleItem with IItemExtension {
+  override protected def canResetComponentIdentity: Boolean = true
+
   override protected def tooltipExtended(stack: ItemStack, tooltip: util.List[Component]): Unit = {
     super.tooltipExtended(stack, tooltip)
     val data = new DebugCardData(stack)

--- a/src/main/scala/li/cil/oc/common/item/InternetCard.scala
+++ b/src/main/scala/li/cil/oc/common/item/InternetCard.scala
@@ -5,4 +5,6 @@ import net.minecraft.world.item.Item.Properties
 import net.neoforged.neoforge.common.extensions.IItemExtension
 
 
-class InternetCard(props: Properties) extends Item(props) with traits.SimpleItem with traits.ItemTier with IItemExtension
+class InternetCard(props: Properties) extends Item(props) with traits.SimpleItem with traits.ItemTier with IItemExtension {
+  override protected def canResetComponentIdentity: Boolean = true
+}

--- a/src/main/scala/li/cil/oc/common/item/NetworkCard.scala
+++ b/src/main/scala/li/cil/oc/common/item/NetworkCard.scala
@@ -5,4 +5,6 @@ import net.minecraft.world.item.Item.Properties
 import net.neoforged.neoforge.common.extensions.IItemExtension
 
 
-class NetworkCard(props: Properties) extends Item(props) with traits.SimpleItem with traits.ItemTier with IItemExtension
+class NetworkCard(props: Properties) extends Item(props) with traits.SimpleItem with traits.ItemTier with IItemExtension {
+  override protected def canResetComponentIdentity: Boolean = true
+}

--- a/src/main/scala/li/cil/oc/common/item/RedstoneCard.scala
+++ b/src/main/scala/li/cil/oc/common/item/RedstoneCard.scala
@@ -10,4 +10,6 @@ class RedstoneCard(props: Properties, val tier: Int) extends Item(props) with tr
   override def getDescriptionId = super.getDescriptionId + tier
 
   override protected def tooltipName = Option(unlocalizedName)
+
+  override protected def canResetComponentIdentity: Boolean = true
 }

--- a/src/main/scala/li/cil/oc/common/item/WirelessNetworkCard.scala
+++ b/src/main/scala/li/cil/oc/common/item/WirelessNetworkCard.scala
@@ -10,4 +10,6 @@ class WirelessNetworkCard(props: Properties, var tier: Int) extends Item(props) 
   override def getDescriptionId = super.getDescriptionId + tier
   
   override protected def tooltipName = Option(unlocalizedName)
+
+  override protected def canResetComponentIdentity: Boolean = true
 }


### PR DESCRIPTION
These are all components that don't have any persistent state outside of a running computer as far as I know, so they should all be safe to clean UUIDs from:

- CPU and APU
- Audio Card
- Data Cards
- LAN and WLAN Cards
- Redstone Cards
- Internet Card

I didn't do Linked Cards out of concern that cleaning them might break the link, and I didn't do any robot upgrades, where technically the cleaning works but there's some other thing causing upgrades not to stack together, so allowing cleaning just results in 3 different strata of upgrades that don't stack with each other.