### PR TITLE
Fix tablet crashing on dedicated server

### DIFF
--- a/src/main/scala/li/cil/oc/client/PacketSender.scala
+++ b/src/main/scala/li/cil/oc/client/PacketSender.scala
@@ -11,7 +11,7 @@ import li.cil.oc.common.blockentity.traits.Computer
 import net.minecraft.client.Minecraft
 import net.minecraft.client.resources.sounds.SimpleSoundInstance
 import net.minecraft.world.item.ItemStack
-import net.minecraft.core.Direction
+import net.minecraft.core.{Direction, RegistryAccess}
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.sounds.SoundEvents
 
@@ -119,10 +119,10 @@ object PacketSender {
     }
   }
 
-  def sendMachineItemStateRequest(stack: ItemStack): Unit = {
+  def sendMachineItemStateRequest(stack: ItemStack, registryAccess: RegistryAccess): Unit = {
     val pb = new SimplePacketBuilder(PacketType.MachineItemStateRequest)
 
-    pb.writeItemStack(stack)
+    pb.writeItemStack(stack, registryAccess)
 
     pb.sendToServer()
   }

--- a/src/main/scala/li/cil/oc/common/PacketBuilder.scala
+++ b/src/main/scala/li/cil/oc/common/PacketBuilder.scala
@@ -3,7 +3,7 @@ package li.cil.oc.common
 import li.cil.oc.Settings
 import li.cil.oc.api.network.EnvironmentHost
 import li.cil.oc.util.BlockPosition
-import net.minecraft.core.{Direction, Registry}
+import net.minecraft.core.{Direction, Registry, RegistryAccess}
 import net.minecraft.nbt.{CompoundTag, NbtIo}
 import net.minecraft.server.level.{ServerLevel, ServerPlayer}
 import net.minecraft.world.entity.Entity
@@ -50,11 +50,11 @@ abstract class PacketBuilder(stream: OutputStream) extends DataOutputStream(stre
     case _ => writeByte(-1: Byte)
   }
 
-  def writeItemStack(stack: ItemStack) = {
+  def writeItemStack(stack: ItemStack, registryAccess: RegistryAccess): Unit = {
     val haveStack = !stack.isEmpty && stack.getCount > 0
     writeBoolean(haveStack)
     if (haveStack) {
-      writeNBT(stack.save(ServerLifecycleHooks.getCurrentServer.registryAccess()).asInstanceOf[CompoundTag])
+      writeNBT(stack.save(registryAccess).asInstanceOf[CompoundTag])
     }
   }
 

--- a/src/main/scala/li/cil/oc/common/item/Tablet.scala
+++ b/src/main/scala/li/cil/oc/common/item/Tablet.scala
@@ -401,7 +401,7 @@ class TabletWrapper(var stack: ItemStack, var player: Player) extends ComponentI
           buffer.setMaximumResolution(80, 25)
       }
 
-      client.PacketSender.sendMachineItemStateRequest(stack)
+      client.PacketSender.sendMachineItemStateRequest(stack, level.registryAccess())
     }
     if (!level.isClientSide) {
       if (isCreative && level.getGameTime % Settings.get.tickFrequency == 0) {
@@ -536,7 +536,7 @@ object Tablet {
               if (timesChanged != weak.timesChanged) {
                 if (!weak.isDirty) {
                   weak.isDirty = true
-                  client.PacketSender.sendMachineItemStateRequest(stack)
+                  client.PacketSender.sendMachineItemStateRequest(stack, holder.level.registryAccess())
                 }
                 weak.timesChanged = timesChanged
               }

--- a/src/main/scala/li/cil/oc/server/PacketSender.scala
+++ b/src/main/scala/li/cil/oc/server/PacketSender.scala
@@ -154,7 +154,7 @@ object PacketSender {
   def sendMachineItemState(player: ServerPlayer, stack: ItemStack, isRunning: Boolean): Unit = {
     val pb = new SimplePacketBuilder(PacketType.MachineItemStateResponse)
 
-    pb.writeItemStack(stack)
+    pb.writeItemStack(stack, player.server.registryAccess())
     pb.writeBoolean(isRunning)
 
     pb.sendToPlayer(player)
@@ -307,7 +307,7 @@ object PacketSender {
     val pb = new SimplePacketBuilder(PacketType.FloppyChange)
 
     pb.writeTileEntity(t)
-    pb.writeItemStack(stack)
+    pb.writeItemStack(stack, t.getLevel.registryAccess())
 
     pb.sendToPlayersNearTileEntity(t)
   }
@@ -425,14 +425,14 @@ object PacketSender {
     for (stack <- stacks) {
       val pb = new SimplePacketBuilder(PacketType.LootDisk)
 
-      pb.writeItemStack(stack)
+      pb.writeItemStack(stack, p.server.registryAccess())
 
       pb.sendToPlayer(p)
     }
     for (stack <- Loot.disksForCyclingServer) {
       val pb = new SimplePacketBuilder(PacketType.CyclingDisk)
 
-      pb.writeItemStack(stack)
+      pb.writeItemStack(stack, p.server.registryAccess())
 
       pb.sendToPlayer(p)
     }
@@ -556,7 +556,7 @@ object PacketSender {
     pb.writeInt(t.getContainerSize)
     for (slot <- 0 until t.getContainerSize) {
       pb.writeInt(slot)
-      pb.writeItemStack(t.getItem(slot))
+      pb.writeItemStack(t.getItem(slot), t.getLevel.registryAccess())
     }
 
     pb.sendToPlayersNearTileEntity(t)
@@ -568,7 +568,7 @@ object PacketSender {
     pb.writeTileEntity(t)
     pb.writeInt(1)
     pb.writeInt(slot)
-    pb.writeItemStack(t.getItem(slot))
+    pb.writeItemStack(t.getItem(slot), t.getLevel.registryAccess())
 
     pb.sendToPlayersNearTileEntity(t)
   }
@@ -655,7 +655,7 @@ object PacketSender {
 
     pb.writeTileEntity(t.proxy)
     pb.writeInt(slot)
-    pb.writeItemStack(stack)
+    pb.writeItemStack(stack, t.getLevel.registryAccess())
 
     pb.sendToPlayersNearTileEntity(t)
   }


### PR DESCRIPTION
Use direct registry access for item stack serialization so tablet updates don't call the server lifecycle hook on the client.