### PR TITLE
Remove redundant model registration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/actions/wrapper-validation@v6
       - uses: actions/cache@v4
         with:
           path: |

--- a/src/main/scala/li/cil/oc/client/ColorHandler.scala
+++ b/src/main/scala/li/cil/oc/client/ColorHandler.scala
@@ -6,14 +6,12 @@ import li.cil.oc.common.block.ChameliumBlock
 import li.cil.oc.common.datacomponents.OCComponents
 import li.cil.oc.common.init.{OCBlocks, OCItems}
 import li.cil.oc.util.{Color, ItemColorizer, ItemUtils}
-import net.minecraft.world.item.DyeColor
+import net.minecraft.util.FastColor
+import net.minecraft.world.item.{DyeColor, ItemStack}
 import net.neoforged.bus.api.SubscribeEvent
 import net.neoforged.neoforge.client.event.RegisterColorHandlersEvent
 
 object ColorHandler {
-  private def opaque(color: Int): Int =
-    0xFF000000 | (color & 0x00FFFFFF)
-
   @SubscribeEvent
   def onRegisterBlocks(event: RegisterColorHandlersEvent.Block): Unit = {
     event.register((state, world, pos, tintIndex) => state.getBlock match {
@@ -53,11 +51,11 @@ object ColorHandler {
   @SubscribeEvent
   def onRegisterItems(event: RegisterColorHandlersEvent.Item): Unit = {
     event.register((stack, tintIndex) =>
-      if (ItemColorizer.hasColor(stack)) opaque(ItemColorizer.getColor(stack)) else 0xFFFFFFFF,
+      if (ItemColorizer.hasColor(stack)) FastColor.ARGB32.opaque(ItemColorizer.getColor(stack)) else 0xFFFFFFFF,
       OCBlocks.Cable.get())
 
     event.register((stack, tintIndex) =>
-      opaque(Color.byTier(ItemUtils.caseTier(stack))),
+      FastColor.ARGB32.opaque(Color.byTier(ItemUtils.caseTier(stack))),
       OCBlocks.CaseTier1.get(),
       OCBlocks.CaseTier2.get(),
       OCBlocks.CaseTier3.get(),
@@ -65,7 +63,7 @@ object ColorHandler {
       OCBlocks.CaseCreative.get())
 
     event.register((stack, tintIndex) =>
-      opaque(Color.rgbValues(stack.getOrDefault(OCComponents.CHAMELIUM_COLOR.get(), ChameliumBlock.DEFAULT_COLOR))),
+      FastColor.ARGB32.opaque(Color.rgbValues(stack.getOrDefault(OCComponents.CHAMELIUM_COLOR.get(), ChameliumBlock.DEFAULT_COLOR))),
       OCBlocks.ChameliumBlock.get())
 
     event.register((stack, tintIndex) => 0xFFFFFFFF,
@@ -75,11 +73,14 @@ object ColorHandler {
       OCBlocks.Print.get(),
       OCBlocks.Robot.get())
 
-    event.register((stack, tintIndex) =>
-      if (tintIndex == 1) {
-        val rgb = if (ItemColorizer.hasColor(stack)) ItemColorizer.getColor(stack) else 0x66DD55
-        opaque(rgb)
-      } else 0xFFFFFFFF,
-      OCItems.HoverBoots.get())
+    event.register((stack, tintIndex) => tintIndex match {
+      case 1 => FastColor.ARGB32.opaque(if (ItemColorizer.hasColor(stack)) ItemColorizer.getColor(stack) else 0x66DD55)
+      case _ => 0xFFFFFFFF
+    }, OCItems.HoverBoots.get())
+
+    event.register((stack: ItemStack, tintIndex: Int) => tintIndex match {
+      case 1 => stack.getOrDefault(OCComponents.DISK_COLOR.get(), DyeColor.GRAY).getTextureDiffuseColor
+      case _ => 0xFFFFFFFF
+    }, OCItems.Floppy.get())
   }
 }

--- a/src/main/scala/li/cil/oc/client/Proxy.scala
+++ b/src/main/scala/li/cil/oc/client/Proxy.scala
@@ -6,15 +6,13 @@ import li.cil.oc.client.renderer._
 import li.cil.oc.client.renderer.block.{ModelInitialization, NetSplitterModel}
 import li.cil.oc.client.renderer.entity.{DroneRenderer, ModelQuadcopter, TrainRobotRenderer}
 import li.cil.oc.client.renderer.tileentity._
+import li.cil.oc.common.{PacketHandler => CommonPacketHandler, Proxy => CommonProxy}
 import li.cil.oc.common.blockentity.BlockEntityTypes
 import li.cil.oc.common.component.TextBuffer
 import li.cil.oc.common.entity.EntityTypes
 import li.cil.oc.common.event.{NanomachinesHandler, RackMountableRenderHandler}
-import li.cil.oc.common.{PacketHandler => CommonPacketHandler, Proxy => CommonProxy}
 import li.cil.oc.util.Audio
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderers
-import net.minecraft.world.item.Item
-import net.minecraft.world.level.block.Block
 import net.neoforged.bus.api.{IEventBus, SubscribeEvent}
 import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent
 import net.neoforged.neoforge.client.event.{EntityRenderersEvent, RegisterKeyMappingsEvent}
@@ -39,23 +37,18 @@ private[oc] class Proxy(modBus: IEventBus) extends CommonProxy(modBus) {
 
     CommonPacketHandler.clientHandler = PacketHandler
 
-    e.enqueueWork((() => {
-      ModelInitialization.preInit()
-
-      NeoForge.EVENT_BUS.register(HighlightRenderer)
-      NeoForge.EVENT_BUS.register(NanomachinesHandler.Client)
-      NeoForge.EVENT_BUS.register(PetRenderer)
-      NeoForge.EVENT_BUS.register(RackMountableRenderHandler)
-      NeoForge.EVENT_BUS.register(Sound)
-      NeoForge.EVENT_BUS.register(TextBuffer)
-      NeoForge.EVENT_BUS.register(MFUTargetRenderer)
-      NeoForge.EVENT_BUS.register(WirelessNetworkDebugRenderer)
-      NeoForge.EVENT_BUS.register(Audio)
-      NeoForge.EVENT_BUS.register(HologramRenderer)
-      NeoForge.EVENT_BUS.register(ScreenRenderer)
-      NeoForge.EVENT_BUS.register(TabletRenderer)
-    }): Runnable)
-
+    NeoForge.EVENT_BUS.register(HighlightRenderer)
+    NeoForge.EVENT_BUS.register(NanomachinesHandler.Client)
+    NeoForge.EVENT_BUS.register(PetRenderer)
+    NeoForge.EVENT_BUS.register(RackMountableRenderHandler)
+    NeoForge.EVENT_BUS.register(Sound)
+    NeoForge.EVENT_BUS.register(TextBuffer)
+    NeoForge.EVENT_BUS.register(MFUTargetRenderer)
+    NeoForge.EVENT_BUS.register(WirelessNetworkDebugRenderer)
+    NeoForge.EVENT_BUS.register(Audio)
+    NeoForge.EVENT_BUS.register(HologramRenderer)
+    NeoForge.EVENT_BUS.register(ScreenRenderer)
+    NeoForge.EVENT_BUS.register(TabletRenderer)
   }
 
   @SubscribeEvent
@@ -99,8 +92,4 @@ private[oc] class Proxy(modBus: IEventBus) extends CommonProxy(modBus) {
   def onRegisterPayloads(event: RegisterPayloadHandlersEvent): Unit = {
     registerPacket(event)
   }
-
-  override def registerModel(instance: Item, id: String): Unit = ModelInitialization.registerModel(instance, id)
-
-  override def registerModel(instance: Block, id: String): Unit = ModelInitialization.registerModel(instance, id)
 }

--- a/src/main/scala/li/cil/oc/client/renderer/block/ModelInitialization.scala
+++ b/src/main/scala/li/cil/oc/client/renderer/block/ModelInitialization.scala
@@ -1,15 +1,12 @@
 package li.cil.oc.client.renderer.block
 
-import li.cil.oc.{Constants, Settings, api}
-import li.cil.oc.common.datacomponents.OCComponents
-import net.minecraft.client.Minecraft
+import li.cil.oc.{Constants, Settings}
+import li.cil.oc.common.init.OCBlocks
 import net.minecraft.client.renderer.block.BlockModelShaper
 import net.minecraft.client.resources.model.{BakedModel, ModelResourceLocation}
-import net.minecraft.core.component.DataComponents
 import net.minecraft.resources.ResourceLocation
-import net.minecraft.world.item.{DyeColor, Item, ItemStack}
-import net.minecraft.world.level.ItemLike
 import net.minecraft.world.level.block.state.BlockState
+import net.minecraft.world.level.block.Block
 import net.neoforged.api.distmarker.{Dist, OnlyIn}
 import net.neoforged.bus.api.SubscribeEvent
 import net.neoforged.neoforge.client.event.ModelEvent
@@ -21,13 +18,9 @@ object ModelInitialization {
   final val CableBlockLocation           = loc(Constants.BlockName.Cable,             "")
   final val CableItemLocation            = loc(Constants.BlockName.Cable,             "inventory")
   final val NetSplitterBlockLocation     = loc(Constants.BlockName.NetSplitter,       "")
-  final val NetSplitterItemLocation      = loc(Constants.BlockName.NetSplitter,       "inventory")
   final val PrintBlockLocation           = loc(Constants.BlockName.Print,             "")
   final val PrintItemLocation            = loc(Constants.BlockName.Print,             "inventory")
-  final val RobotBlockLocation           = loc(Constants.BlockName.Robot,             "")
   final val RobotItemLocation            = loc(Constants.BlockName.Robot,             "inventory")
-  final val RobotAfterimageBlockLocation = loc(Constants.BlockName.RobotAfterimage,   "")
-  final val RackBlockLocation            = loc(Constants.BlockName.Rack,              "")
 
   private def loc(name: String, variant: String): ModelResourceLocation = {
     val id = ResourceLocation.fromNamespaceAndPath(Settings.resourceDomain, name)
@@ -37,71 +30,20 @@ object ModelInitialization {
 
   private val modelRemappings = mutable.Map.empty[ModelResourceLocation, ModelResourceLocation]
 
-  // Called from ClientProxy.preInit().
-  // Model remappings are intentionally NOT built here: on modern NeoForge the
-  // model bake/reload may already be running while common setup work executes.
-  def preInit(): Unit = {
-    registerItemColors()
-  }
-
   private def rebuildModelRemappings(): Unit = {
     modelRemappings.clear()
-    registerBlockRemapping(Constants.BlockName.Cable,             CableBlockLocation,           CableItemLocation)
-    registerBlockRemapping(Constants.BlockName.NetSplitter,       NetSplitterBlockLocation,     NetSplitterItemLocation)
-    registerBlockRemapping(Constants.BlockName.Print,             PrintBlockLocation,           PrintItemLocation)
-    registerBlockRemapping(Constants.BlockName.Robot,             RobotBlockLocation,           RobotItemLocation)
-    registerBlockRemapping(Constants.BlockName.RobotAfterimage,   RobotAfterimageBlockLocation, null)
+    registerBlockRemapping(OCBlocks.Cable.get(), CableBlockLocation)
+    registerBlockRemapping(OCBlocks.NetSplitter.get(), NetSplitterBlockLocation)
+    registerBlockRemapping(OCBlocks.Print.get(), PrintBlockLocation)
   }
-
-  // Item models are loaded from assets on modern NeoForge.
-  def registerModel(_instance: ItemLike, _id: String): Unit = {}
 
   // ── Dynamic item models ────────────────────────────────────────────────────
 
-  // ── Item colors ────────────────────────────────────────────────────────────
-
-  private def registerItemColors(): Unit = {
-    withItem(Constants.ItemName.Floppy) { item =>
-      Minecraft.getInstance.getItemColors.register(
-        (stack: ItemStack, tintIndex: Int) => {
-          if (tintIndex == 1) {
-            val color =
-              Option(stack.get(OCComponents.DISK_COLOR.get())).getOrElse {
-                if (stack.has(DataComponents.CUSTOM_DATA) && stack.get(DataComponents.CUSTOM_DATA).contains(Settings.namespace + "color")) {
-                  val legacyColor = stack.get(DataComponents.CUSTOM_DATA).copyTag().getInt(Settings.namespace + "color")
-                  DyeColor.byId(legacyColor max 0 min 15)
-                }
-                else DyeColor.GRAY
-              }
-
-            color.getTextureDiffuseColor
-          }
-          else 0xFFFFFFFF
-        },
-        item
-      )
-    }
-  }
-
-  private def withItem(name: String)(f: Item => Unit): Unit =
-    Option(api.Items.get(name)).map(_.item()).filter(_ != null).foreach(f)
-
   // ── Block model state remapping ────────────────────────────────────────────
 
-  private def registerBlockRemapping(
-                                      blockName:     String,
-                                      blockLocation: ModelResourceLocation,
-                                      itemLocation:  ModelResourceLocation
-                                    ): Unit = {
-    val descriptor = api.Items.get(blockName)
-    if (descriptor == null) return
-
-    if (blockLocation != null) {
-      val block = descriptor.block()
-      if (block != null)
-        block.getStateDefinition.getPossibleStates.forEach { state =>
-          modelRemappings += stateToModelLocation(state) -> blockLocation
-        }
+  private def registerBlockRemapping(block: Block, blockLocation: ModelResourceLocation): Unit = {
+    block.getStateDefinition.getPossibleStates.forEach { state =>
+      modelRemappings += stateToModelLocation(state) -> blockLocation
     }
   }
 
@@ -120,9 +62,7 @@ object ModelInitialization {
     registry.put(NetSplitterBlockLocation,     NetSplitterModel)
     registry.put(PrintBlockLocation,           PrintModel)
     registry.put(PrintItemLocation,            PrintModel)
-    registry.put(RobotBlockLocation,           NullModel)
     registry.put(RobotItemLocation,            RobotModel)
-    registry.put(RobotAfterimageBlockLocation, NullModel)
     registry.put(loc(Constants.ItemName.Drone, "inventory"), DroneModel)
 
     val modelOverrides = Map[String, BakedModel => BakedModel](

--- a/src/main/scala/li/cil/oc/client/renderer/block/NullModel.scala
+++ b/src/main/scala/li/cil/oc/client/renderer/block/NullModel.scala
@@ -1,4 +1,0 @@
-package li.cil.oc.client.renderer.block
-
-object NullModel extends SmartBlockModelBase {
-}

--- a/src/main/scala/li/cil/oc/client/renderer/block/ServerRackModel.scala
+++ b/src/main/scala/li/cil/oc/client/renderer/block/ServerRackModel.scala
@@ -63,7 +63,7 @@ class ServerRackModel(val parent: BakedModel) extends SmartBlockModelBase {
           case _ =>
         }
 
-        faces.toList.asJava
+        faces.asJava
       case _ => super.getQuads(state, side, rand)
     }
 

--- a/src/main/scala/li/cil/oc/common/Proxy.scala
+++ b/src/main/scala/li/cil/oc/common/Proxy.scala
@@ -52,7 +52,7 @@ class Proxy(val modBus: IEventBus) {
     if (LuaStateFactory.includeLuaJ) {
       api.Machine.add(classOf[LuaJLuaArchitecture])
     }
-    
+
     api.Machine.LuaArchitecture =
       if (Settings.get.forceLuaJ) classOf[LuaJLuaArchitecture]
       else api.Machine.architectures.asScala.head
@@ -70,10 +70,6 @@ class Proxy(val modBus: IEventBus) {
       api.API.isPowerEnabled = !Settings.get.ignorePower
     }): Runnable)
   }
-
-  def registerModel(instance: Item, id: String): Unit = {}
-
-  def registerModel(instance: Block, id: String): Unit = {}
 
   def registerPacket(event: RegisterPayloadHandlersEvent): Unit = {
     val registrar: PayloadRegistrar = event.registrar(OpenComputers.ID).versioned("1")

--- a/src/main/scala/li/cil/oc/common/init/OCItems.scala
+++ b/src/main/scala/li/cil/oc/common/init/OCItems.scala
@@ -74,11 +74,7 @@ object OCItems extends ItemAPI {
         case simple: SimpleBlock =>
           simple.setUnlocalizedName("oc." + id)
 
-          val ro: DeferredItem[Item] = ITEMS.register(id, () => {
-            val itemInst: Item = new common.block.Item(simple, itemProps)
-            OpenComputers.proxy.registerModel(itemInst, id)
-            itemInst
-          })
+          val ro: DeferredItem[Item] = ITEMS.register(id, () => new common.block.Item(simple, itemProps))
 
           descriptors += id -> new ItemInfo {
             override def name: String = id
@@ -106,11 +102,6 @@ object OCItems extends ItemAPI {
     // Construct items inside the supplier while the registry is writable.
     val ro: DeferredItem[T] = ITEMS.register(id, () => {
       val instance = makeItem
-      instance match {
-        case simple: SimpleItem =>
-          OpenComputers.proxy.registerModel(simple, id)
-        case _ =>
-      }
       names += instance -> id
       instance
     })


### PR DESCRIPTION
 - Move floppy color handler to live with the other items/blocks
 - Remove `ModelInitialization.registerModel` and all callers of it (it's just an empty method).
 - Remove `NullModel` — we already register a blockstate JSON using air.

There's some more cleanup to do here, just trying to avoid creating another massive PR :D. We don't need custom model implementations for drones or cables, and we could definitely move *some* of the the rack and net splitter model to JSON). The less custom model code we have, the easier updating to 26.2 will be.