### PR TITLE
Fix null MatchError in ConverterItemStack when converting AE2 items

### DIFF
--- a/src/main/scala/li/cil/oc/integration/minecraft/ConverterItemStack.scala
+++ b/src/main/scala/li/cil/oc/integration/minecraft/ConverterItemStack.scala
@@ -75,12 +75,14 @@ object ConverterItemStack extends api.driver.Converter {
           case lore: ItemLore => {
             output += "lore" -> lore.lines().map(_.getString).mkString("\n")
           }
+          case _ =>
         }
 
         stack.getCapability(Capabilities.EnergyStorage.ITEM) match {
           case storage: IEnergyStorage => {
             output += "Energy" -> Int.box(storage.getEnergyStored)
           }
+          case _ =>
         }
 
         // custom mod tags

--- a/src/main/scala/li/cil/oc/server/driver/Registry.scala
+++ b/src/main/scala/li/cil/oc/server/driver/Registry.scala
@@ -240,6 +240,10 @@ private[oc] object Registry extends api.detail.DriverAPI {
     val converted = memo.asScala.getOrElseUpdate(obj, mutable.Map.empty[AnyRef, AnyRef]) match {
       case map: mutable.Map[AnyRef, AnyRef]@unchecked => map
       case map: java.util.Map[AnyRef, AnyRef]@unchecked => map.asScala
+      case _ =>
+        val fresh = mutable.Map.empty[AnyRef, AnyRef]
+        memo.asScala += obj -> fresh
+        fresh
     }
     map.collect {
       case (key: AnyRef, value: AnyRef) => converted += convertRecursively(key, memo) -> convertRecursively(value, memo)

--- a/src/main/scala/li/cil/oc/server/machine/CallbackWrapper.scala
+++ b/src/main/scala/li/cil/oc/server/machine/CallbackWrapper.scala
@@ -58,7 +58,15 @@ object CallbackWrapper {
     mv.visitTypeInsn(Opcodes.CHECKCAST, className)
     mv.visitVarInsn(Opcodes.ALOAD, 2)
     mv.visitVarInsn(Opcodes.ALOAD, 3)
-    mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, className, m.getName, Type.getMethodDescriptor(m), false)
+    // Methods discovered via an implemented interface (e.g. default methods
+    // like NetworkControl's @Callback methods) must be invoked with
+    // INVOKEINTERFACE, not INVOKEVIRTUAL. Using INVOKEVIRTUAL against an
+    // interface owner throws IncompatibleClassChangeError at call time.
+    if (m.getDeclaringClass.isInterface) {
+      mv.visitMethodInsn(Opcodes.INVOKEINTERFACE, className, m.getName, Type.getMethodDescriptor(m), true)
+    } else {
+      mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, className, m.getName, Type.getMethodDescriptor(m), false)
+    }
     mv.visitInsn(Opcodes.ARETURN)
     mv.visitMaxs(3, 3)
     mv.visitEnd()

--- a/src/main/scala/li/cil/oc/server/machine/Callbacks.scala
+++ b/src/main/scala/li/cil/oc/server/machine/Callbacks.scala
@@ -81,8 +81,9 @@ object Callbacks {
 
   private def staticAnalyze(seed: Class[_], shouldAdd: Option[String => Boolean] = None, optCallbacks: Option[mutable.Map[String, Callback]] = None) = {
     val callbacks = optCallbacks.getOrElse(mutable.Map.empty[String, Callback])
-    var c: Class[_] = seed
-    while (c != null && c != classOf[Object]) {
+    val visited = mutable.Set.empty[Class[_]]
+
+    def processMethods(c: Class[_]): Unit = {
       val ms = c.getDeclaredMethods
 
       ms.filter(_.isAnnotationPresent(classOf[machine.Callback])).foreach(m =>
@@ -105,9 +106,21 @@ object Callbacks {
           }
         }
       )
-
-      c = c.getSuperclass
     }
+
+    // getDeclaredMethods only ever returns methods declared directly on a
+    // class, never default methods inherited from implemented interfaces
+    // (e.g. NetworkControl's @Callback defaults). Walking only
+    // getSuperclass, as before, silently drops every interface-provided
+    // callback. Recurse into interfaces (and their super-interfaces) too.
+    def visit(c: Class[_]): Unit = {
+      if (c == null || c == classOf[Object] || !visited.add(c)) return
+      processMethods(c)
+      c.getInterfaces.foreach(visit)
+      visit(c.getSuperclass)
+    }
+
+    visit(seed)
     callbacks
   }
 


### PR DESCRIPTION
## Root cause

`scala.MatchError: null` in `ConverterItemStack.scala` (~line 80) when converting item stacks that carry NBT/data components AE2 relies on. `stack.get(DataComponents.LORE)` and the energy storage capability lookup both return `null` for the vast majority of items (any item with no lore, any item without an energy capability, including every AE2 item), and the `match` expressions handling them had no fallback case. Since this runs unconditionally on every `ItemStack` passed through `Registry.convert`, any inventory read (e.g. via `inventory_controller`) against an AE2 block threw this on essentially the first item it touched.

## Fix

Added `case _ =>` to both non-exhaustive matches in `ConverterItemStack.scala` so items without lore or an energy capability convert normally instead of crashing.

## Also includes

While tracing this, found and fixed three related issues in the same conversion/callback path:

- **`Registry.scala`** (`convertMap`): same class of bug — a non-exhaustive match with no fallback for the memoized value, reachable through re-entrant conversion of the same object identity.
- **`Callbacks.scala`** (`staticAnalyze`): the `@Callback` method scanner only walked `getSuperclass`, never `getInterfaces`. `getDeclaredMethods` doesn't return default methods inherited from an interface, so any `@Callback` default method declared on an interface (e.g. `NetworkControl`, implemented by `DriverController.Environment` for AE2's `me_controller`) was silently never registered — `me_controller` only ever exposed its directly-declared energy methods, never `getItemsInNetwork`/`getCraftables`/etc.
- **`CallbackWrapper.scala`** (`emitCallbackCall`): fixing the above surfaced a second bug — the generated bytecode always used `INVOKEVIRTUAL`, which throws `IncompatibleClassChangeError` when the method is declared on an interface rather than a class. That exception has no handler in `Component.invoke`, so it surfaced as a silent `nil` result instead of a value or a visible error. Now emits `INVOKEINTERFACE` when the declaring class is an interface.

## Testing

Tested locally against NeoForge 1.21.1 + Applied Energistics 2 19.2.17 + a locally built `opencomputers-1.9.4-dev.local` jar from this branch. Confirmed:
- `inventory_controller` reads against AE2 blocks (controller, interface, import/export bus) no longer throw `scala.MatchError: null`.
- `me_controller.getItemsInNetwork()` / `getCraftables()` / `getCpus()` / `getFluidsInNetwork()` now return actual data instead of being unreachable or `nil`.
