### PR TITLE
Add OpenComputers driver for Create Crafts & Additions Accumulator block

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -258,6 +258,10 @@ dependencies {
     runtimeOnly("mekanism:Mekanism:${mekanism_version}")
     runtimeOnly("mekanism:Mekanism:${mekanism_version}:generators")
 
+    // Create: Crafts & Additions
+    compileOnly("maven.modrinth:createaddition:${createaddition_version}")
+    runtimeOnly("maven.modrinth:createaddition:${createaddition_version}")
+
     // JEI
     compileOnly("mezz.jei:${jeiSlug}-neoforge-api:${jei_version}")
     devRuntimeOnly("mezz.jei:${jeiSlug}-neoforge:${jei_version}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,6 +25,7 @@ ae2_version=19.2.17
 cct_version=1.120.0
 jei_version=19.27.0.336
 mekanism_version=1.21.1-10.7.19.85
+createaddition_version=neoforge-1.21.1-1.6.0
 modernfix_version=5.27.11+mc1.21.1
 projred_version=1.21.1-4.22.0
 ccl_version=1.21.1-4.6.1.529

--- a/src/main/scala/li/cil/oc/integration/Mods.scala
+++ b/src/main/scala/li/cil/oc/integration/Mods.scala
@@ -26,6 +26,7 @@ object Mods {
   val JustEnoughItems = new SimpleMod(IDs.JustEnoughItems)
   val AppliedEnergistics2 = new SimpleMod(IDs.AppliedEnergistics2)
   val Mekanism = new SimpleMod(IDs.Mekanism)
+  val CreateAddition = new SimpleMod(IDs.CreateAddition)
   val Minecraft = new SimpleMod(IDs.Minecraft)
   val OpenComputers = new SimpleMod(IDs.OpenComputers)
   val EnderStorage = new SimpleMod(IDs.EnderStorage)
@@ -40,6 +41,7 @@ object Mods {
     integration.minecraft.ModMinecraft,
     integration.computercraft.ModComputerCraft,
     integration.appeng.ModAppliedEnergistics2.INSTANCE,
+    integration.createaddition.ModCreateAddition.INSTANCE,
     integration.enderstorage.ModEnderStorage,
     integration.projectred.ModProjectRed,
 
@@ -101,6 +103,7 @@ object Mods {
     final val JustEnoughItems = "jei"
     final val AppliedEnergistics2 = "ae2"
     final val Mekanism = "mekanism"
+    final val CreateAddition = "createaddition"
     final val Minecraft = "minecraft"
     final val OpenComputers = "opencomputers"
     final val EnderStorage = "enderstorage"

--- a/src/main/scala/li/cil/oc/integration/createaddition/DriverAccumulator.java
+++ b/src/main/scala/li/cil/oc/integration/createaddition/DriverAccumulator.java
@@ -1,0 +1,106 @@
+package li.cil.oc.integration.createaddition;
+
+import com.mrh0.createaddition.blocks.modular_accumulator.ModularAccumulatorBlockEntity;
+import com.mrh0.createaddition.config.CommonConfig;
+import com.mrh0.createaddition.index.CABlocks;
+import li.cil.oc.api.driver.EnvironmentProvider;
+import li.cil.oc.api.driver.NamedBlock;
+import li.cil.oc.api.machine.Arguments;
+import li.cil.oc.api.machine.Callback;
+import li.cil.oc.api.machine.Context;
+import li.cil.oc.api.network.ManagedEnvironment;
+import li.cil.oc.api.prefab.DriverSidedBlockEntity;
+import li.cil.oc.integration.ManagedBlockEntityEnvironment;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+
+public final class DriverAccumulator extends DriverSidedBlockEntity {
+    public static final DriverAccumulator INSTANCE = new DriverAccumulator();
+
+    private DriverAccumulator() {
+    }
+
+    @Override
+    public Class<?> getBlockEntityClass() {
+        return ModularAccumulatorBlockEntity.class;
+    }
+
+    @Override
+    public ManagedEnvironment createEnvironment(final Level world, final BlockPos pos, final Direction side) {
+        return new Environment((ModularAccumulatorBlockEntity) world.getBlockEntity(pos));
+    }
+
+    public static final class Environment extends ManagedBlockEntityEnvironment<ModularAccumulatorBlockEntity> implements NamedBlock {
+        public Environment(final ModularAccumulatorBlockEntity tile) {
+            super(tile, "cca_accumulator");
+        }
+
+        @Override
+        public String preferredName() {
+            return "cca_accumulator";
+        }
+
+        @Override
+        public int priority() {
+            return 0;
+        }
+
+        // The accumulator only tracks energy on its controller part; every
+        // part of the multiblock forwards reads to it, same as the CC:Tweaked
+        // peripheral (ModularAccumulatorPeripheral) this mirrors.
+        private ModularAccumulatorBlockEntity controller() {
+            return blockEntity.getControllerBE();
+        }
+
+        @Callback(doc = "function():number -- Get the current energy stored in the accumulator, in FE.")
+        public Object[] getEnergyStored(final Context context, final Arguments args) {
+            final ModularAccumulatorBlockEntity controller = controller();
+            return new Object[]{controller == null ? 0 : controller.getEnergy().getEnergyStored()};
+        }
+
+        @Callback(doc = "function():number -- Get the maximum energy the accumulator can store, in FE.")
+        public Object[] getMaxEnergyStored(final Context context, final Arguments args) {
+            final ModularAccumulatorBlockEntity controller = controller();
+            return new Object[]{controller == null ? 0 : controller.getEnergy().getMaxEnergyStored()};
+        }
+
+        @Callback(doc = "function():number -- Get the current charge of the accumulator, in percent (0-100).")
+        public Object[] getEnergyPercent(final Context context, final Arguments args) {
+            return new Object[]{blockEntity.getCurrentValue()};
+        }
+
+        @Callback(doc = "function():number -- Get the maximum energy transfer per side, in FE/t.")
+        public Object[] getMaxInsert(final Context context, final Arguments args) {
+            return new Object[]{CommonConfig.ACCUMULATOR_MAX_INPUT.get()};
+        }
+
+        @Callback(doc = "function():number -- Get the maximum energy extraction per side, in FE/t.")
+        public Object[] getMaxExtract(final Context context, final Arguments args) {
+            return new Object[]{CommonConfig.ACCUMULATOR_MAX_OUTPUT.get()};
+        }
+
+        @Callback(doc = "function():number -- Get the height of the accumulator multiblock, in blocks.")
+        public Object[] getHeight(final Context context, final Arguments args) {
+            return new Object[]{blockEntity.getHeight()};
+        }
+
+        @Callback(doc = "function():number -- Get the width of the accumulator multiblock, in blocks.")
+        public Object[] getWidth(final Context context, final Arguments args) {
+            return new Object[]{blockEntity.getWidth()};
+        }
+    }
+
+    public static final class Provider implements EnvironmentProvider {
+        public static final Provider INSTANCE = new Provider();
+
+        private Provider() {
+        }
+
+        @Override
+        public Class<?> getEnvironment(final ItemStack stack) {
+            return stack.getItem() == CABlocks.MODULAR_ACCUMULATOR.get().asItem() ? Environment.class : null;
+        }
+    }
+}

--- a/src/main/scala/li/cil/oc/integration/createaddition/ModCreateAddition.java
+++ b/src/main/scala/li/cil/oc/integration/createaddition/ModCreateAddition.java
@@ -1,0 +1,23 @@
+package li.cil.oc.integration.createaddition;
+
+import li.cil.oc.api.Driver;
+import li.cil.oc.integration.ModProxy;
+import li.cil.oc.integration.Mods;
+
+public final class ModCreateAddition implements ModProxy {
+    public static final ModCreateAddition INSTANCE = new ModCreateAddition();
+
+    private ModCreateAddition() {
+    }
+
+    @Override
+    public li.cil.oc.integration.Mod getMod() {
+        return Mods.CreateAddition();
+    }
+
+    @Override
+    public void initialize() {
+        Driver.add(DriverAccumulator.Provider.INSTANCE);
+        Driver.add(DriverAccumulator.INSTANCE);
+    }
+}


### PR DESCRIPTION
## What

Adds a new integration driver exposing [Create: Crafts & Additions](https://github.com/mrh0/createaddition)' Modular Accumulator multiblock as an OC component (`cca_accumulator`) when an Adapter is placed directly adjacent to it. No Inventory Controller Upgrade is required — this is a direct block driver, not an inventory-slot driver.

## Why

There was no existing OC support for this block. Create: Crafts & Additions only ships a CC:Tweaked peripheral (`ModularAccumulatorPeripheral`) for it.

## Implementation

- `DriverAccumulator.java` mirrors the existing `DriverController`/`ManagedBlockEntityEnvironment` pattern used for AE2's controller block: a `DriverSidedBlockEntity` matched on `ModularAccumulatorBlockEntity.class`, with an `EnvironmentProvider` gated on the accumulator's item.
- Energy and percent charge are read through the multiblock's controller part (`ModularAccumulatorBlockEntity.getControllerBE()`), the same indirection the mod's own ComputerCraft peripheral uses — every part of the multiblock forwards to the controller, which is the only part actually tracking energy.
- `getMaxInsert`/`getMaxExtract` come from the mod's static server config (`CommonConfig.ACCUMULATOR_MAX_INPUT`/`ACCUMULATOR_MAX_OUTPUT`), not per-instance state, since the block has no per-side transfer rate to read.
- Registered as a soft dependency through the existing `Mods.scala`/`Proxies` mechanism (`SimpleMod` + `ModProxy`), the same pattern used for the AE2 and Mekanism integrations: `compileOnly`/`runtimeOnly` on the mod jar in `build.gradle`, with `initialize()` only running if `createaddition` is actually loaded. No entry was added to `neoforge.mods.toml` — checked, and none of the existing third-party integrations (AE2, Mekanism, JEI) declare one there either, so this follows the established convention rather than deviating from it.

## Exposed methods

All read-only:

- `getEnergyStored()` — current energy stored, in FE
- `getMaxEnergyStored()` — max energy capacity, in FE
- `getEnergyPercent()` — current charge, 0–100
- `getMaxInsert()` — max energy transfer per side, in FE/t
- `getMaxExtract()` — max energy extraction per side, in FE/t
- `getHeight()` — multiblock height, in blocks
- `getWidth()` — multiblock width, in blocks

## Testing

Tested locally against NeoForge 1.21.1 + Create: Crafts & Additions + a locally built `opencomputers-1.9.4-dev.local` jar from this branch. Confirmed:
- `getEnergyStored`/`getMaxEnergyStored`/`getEnergyPercent` update live as the accumulator charges.
- `getHeight`/`getWidth` correctly report multiblock size, verified on both a 1x1 and a 4x2 configuration.
