### PR TITLE
Restore CPU architecture cycling by moving to plain right-click

### DIFF
--- a/src/main/scala/li/cil/oc/common/item/traits/CPULike.scala
+++ b/src/main/scala/li/cil/oc/common/item/traits/CPULike.scala
@@ -42,7 +42,7 @@ trait CPULike extends SimpleItem {
               val archClass = architectures(newIndex)
               val archName = api.Machine.getArchitectureName(archClass)
               driver.setArchitecture(stack, archClass)
-              player.sendSystemMessage(Component.translatable(Settings.namespace + "tooltip.cpu.Architecture", archName))
+              player.displayClientMessage(Component.translatable(Settings.namespace + "tooltip.cpu.Architecture", archName), true)
             }
             player.swing(InteractionHand.MAIN_HAND)
           case _ => // No known driver for this processor.

--- a/src/main/scala/li/cil/oc/common/item/traits/CPULike.scala
+++ b/src/main/scala/li/cil/oc/common/item/traits/CPULike.scala
@@ -31,7 +31,7 @@ trait CPULike extends SimpleItem {
   }
 
   override def use(stack: ItemStack, level: Level, player: Player): InteractionResultHolder[ItemStack] = {
-    if (player.isCrouching) {
+    if (!player.isCrouching) {
       if (!level.isClientSide) {
         api.Driver.driverFor(stack) match {
           case driver: MutableProcessor =>


### PR DESCRIPTION
It turns out that architecture cycling feature got broken when CPUs were opted into the data-cleaning shift-right-click behavior and got overriden. Oops! Fix this by moving the cycling behavior to plain right-click. It's a little easier now to accidentally change a CPU-like's architecture when you didn't intend, but this is not a destructive action (all you have to do is cycle through the list until you get back to the one you want again) so it should be fine.

Also, change the output to be in the little tooltip area thing instead of in the chat.