### PR TITLE
Additional CONTRIBUTING edits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,3 +12,18 @@ AI-generated works are based on sources of unknown origin and present potential
 copyright ownership issues. The best way to respect all parties involved is to
 reject further uses of AI in this project and remove what already exists. This
 policy mirrors similar ones to SDL and UZDoom.
+
+If used to submit a PR to the OpenComputers: Rebooted repository, you *must*
+disclose both the fact you were involved in the creation of the PR, and to what
+extent as required in the CONTRIBUTING.md file. Examples of things requiring
+disclosure include, but are not limited to:
+- How much code generated or altered by you is used in the submitted PR and
+  future alterations to it.
+- The extent you authored or edited any human-readable descriptions, including
+  git commit messages, PR descriptions, and any responses to feedback offered by
+  maintainers.
+  - In particular, you *must* be listed as an author or co-author on any commits
+    containing any content introduced or altered by you, including commit
+    messages themselves.
+- Human-readable documentation, such as the Markdown files used in the in-game
+  manual.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,3 +12,18 @@ AI-generated works are based on sources of unknown origin and present potential
 copyright ownership issues. The best way to respect all parties involved is to
 reject further uses of AI in this project and remove what already exists. This
 policy mirrors similar ones to SDL and UZDoom.
+
+If used to submit a PR to the OpenComputers: Rebooted repository, you *must*
+disclose both the fact you were involved in the creation of the PR, and to what
+extent as required in the CONTRIBUTING.md file. Examples of things requiring
+disclosure include, but are not limited to:
+- How much code generated or altered by you is used in the submitted PR and
+  future alterations to it.
+- The extent you authored or edited any human-readable descriptions, including
+  git commit messages, PR descriptions, and any responses to feedback offered by
+  maintainers.
+  - In particular, you *must* be listed as an author or co-author on any commits
+    containing any content introduced or altered by you, including commit
+    messages themselves.
+- Human-readable documentation, such as the Markdown files used in the in-game
+  manual.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,12 @@ make sense for the OpenComputers team to maintain drivers that logically belong
 to other mods.
 
 Exceptions can be made on a case-by-case basis if there is a compelling reason
-to do so.
+to do so. The current exceptions for mod drivers that live in OpenComputers
+directly:
+- Create (base Create only, none of the add-ons)
+- Mekanism
+- Applied Energistics 2
+- Project Red
 
 ## AI Policy
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,12 @@ We're currently focusing on getting the 1.21 version up to date with modern
 modding practices (such as being easily configurable with datapacks) and
 squishing bugs.
 
+It is unlikely that we are going to add any more new blocks or items to the base
+mod at this time. However, we are happy to collaborate on extending the
+OpenComputers API if it doesn't yet have everything you need to implement your
+ideas as an add-on! In that case, drop us a line on Github or our IRC channels
+and we can discuss how to make things work for everyone.
+
 Translations live in
 [`src/main/resources/assets/opencomputers/lang`](src/main/resources/assets/opencomputers/lang).
 The English locale is the source of truth for keys. Instructions for adding

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,3 +64,6 @@ significant amount of your contribution.
 
 See [SDL's `AGENTS.md`](https://github.com/libsdl-org/SDL/blob/main/AGENTS.md)
 for some additional rationale.
+
+Even in cases otherwise deemed acceptable, Any use of AI output in contributions
+submitted to this repository must be disclosed when submitting your PR.


### PR DESCRIPTION
Further edits to CONTRIBUTING:
- Require disclosure of the use of AI when used under our 'acceptable circumstances' (aka 'trivial changes') provision. This includes new instructions in agent files to that effect.
- Specifically list what mods have the 'driver-in-core' exception, which is:
  - Create (base mod only, no addons)
  - Mekanism
  - Applied Energistics 2
  - Project: Red
- Mention that, at least for the foreseeable future, it's not likely that we'll take new items/blocks, but that we are happy to extend the OpenComputers API to help make dreams come true.