### PR TITLE
Remove overrides of `use(...)`

### DIFF
--- a/src/main/scala/li/cil/oc/common/entity/Drone.scala
+++ b/src/main/scala/li/cil/oc/common/entity/Drone.scala
@@ -15,7 +15,6 @@ import li.cil.oc.common.{EventHandler, menu}
 import li.cil.oc.integration.util.Wrench
 import li.cil.oc.server.{agent, component}
 import li.cil.oc.util.ExtendedLevel._
-import li.cil.oc.util.ExtendedNBT._
 import li.cil.oc.util.ExtendedDataComponentHolder._
 import li.cil.oc.util.{BlockPosition, InventoryUtils}
 import net.minecraft.core.component.DataComponentHolder
@@ -24,7 +23,7 @@ import net.minecraft.nbt.CompoundTag
 import net.minecraft.network.chat.Component
 import net.minecraft.network.protocol.game.ClientboundAddEntityPacket
 import net.minecraft.network.syncher.{EntityDataAccessor, EntityDataSerializers, SynchedEntityData}
-import net.minecraft.server.level.{ServerEntity, ServerLevel, ServerPlayer}
+import net.minecraft.server.level.{ServerEntity, ServerPlayer}
 import net.minecraft.util.ColorRGBA
 import net.minecraft.world.entity._
 import net.minecraft.world.entity.item.ItemEntity
@@ -36,7 +35,6 @@ import net.minecraft.world.level.block.state.BlockState
 import net.minecraft.world.level.portal.DimensionTransition
 import net.minecraft.world.phys.Vec3
 import net.minecraft.world.{InteractionHand, InteractionResult, MenuProvider}
-import net.neoforged.api.distmarker.{Dist, OnlyIn}
 import net.neoforged.neoforge.common.MutableDataComponentHolder
 import net.neoforged.neoforge.fluids.IFluidTank
 
@@ -65,7 +63,7 @@ abstract class DroneInventory(val drone: Drone) extends Inventory
 // someone decides to ship that specific version of the API.
 class Drone(selfType: EntityType[Drone], level: Level) extends Entity(selfType, level) with MachineHost with internal.Drone with internal.Rotatable with Analyzable with Context with Persistable {
   override def getEnvironmentLevel: Level = level
-  
+
   // Some basic constants.
   val gravity = 0.05f
   // low for slow fall (float down)
@@ -228,7 +226,6 @@ class Drone(selfType: EntityType[Drone], level: Level) extends Entity(selfType, 
 
   override def markChanged(): Unit = {}
 
-  @OnlyIn(Dist.CLIENT)
   override def getRopeHoldPosition(dt: Float): Vec3 =
     getPosition(dt).add(0.0, -0.056, 0.0) // Offset: height * 0.85 * 0.7 - 0.25
 
@@ -278,7 +275,7 @@ class Drone(selfType: EntityType[Drone], level: Level) extends Entity(selfType, 
     builder.define(Drone.DataLightColor, Int.box(0x66DD55))
   }
 
-  def initializeAfterPlacement(stack: ItemStack, player: Player, position: Vec3): Unit = {
+  def initializeAfterPlacement(stack: ItemStack, position: Vec3): Unit = {
     info.loadData(stack)
     control.node.changeBuffer(info.storedEnergy - control.node.localBuffer)
     wireThingsTogether()

--- a/src/main/scala/li/cil/oc/common/init/OCItems.scala
+++ b/src/main/scala/li/cil/oc/common/init/OCItems.scala
@@ -429,7 +429,7 @@ object OCItems extends ItemAPI {
   val DiskDriveMountable: DeferredItem[item.DiskDriveMountable] = registerItem(new item.DiskDriveMountable(defaultProps.stacksTo(1)), Constants.ItemName.DiskDriveMountable)
 
   // 1.9
-  val RAMCreative: DeferredItem[Item] = registerBasicItem(Constants.ItemName.RAMCreative, defaultProps.rarity(Rarity.EPIC))
+  val RAMCreative: DeferredItem[Item] = registerItem(new item.BasicItem(defaultProps.rarity(Rarity.EPIC), "creativememory"), Constants.ItemName.RAMCreative)
   val CapacitorMountable: DeferredItem[Item] = registerBasicItem(Constants.ItemName.CapacitorMountable, defaultProps.stacksTo(1))
 
   // Card components.

--- a/src/main/scala/li/cil/oc/common/item/Acid.scala
+++ b/src/main/scala/li/cil/oc/common/item/Acid.scala
@@ -16,9 +16,9 @@ import net.minecraft.world.effect.MobEffects
 import net.neoforged.neoforge.common.extensions.IItemExtension
 
 class Acid(props: Properties) extends Item(props) with traits.SimpleItem with IItemExtension {
-  override def use(stack: ItemStack, level: Level, player: Player): InteractionResultHolder[ItemStack] = {
-    player.startUsingItem(if (player.getItemInHand(InteractionHand.MAIN_HAND) == stack) InteractionHand.MAIN_HAND else InteractionHand.OFF_HAND)
-    new InteractionResultHolder(InteractionResult.sidedSuccess(level.isClientSide), stack)
+  override def use(level: Level, player: Player, hand: InteractionHand): InteractionResultHolder[ItemStack] = {
+    player.startUsingItem(hand)
+    InteractionResultHolder.sidedSuccess(player.getItemInHand(hand), level.isClientSide)
   }
 
   override def getUseAnimation(stack: ItemStack): UseAnim = UseAnim.DRINK

--- a/src/main/scala/li/cil/oc/common/item/Analyzer.scala
+++ b/src/main/scala/li/cil/oc/common/item/Analyzer.scala
@@ -1,33 +1,25 @@
 package li.cil.oc.common.item
 
-import li.cil.oc.Constants
-import li.cil.oc.Localization
-import li.cil.oc.Settings
-import li.cil.oc.api
+import li.cil.oc.{api, Constants, Localization, Settings}
 import li.cil.oc.api.machine.Machine
-import li.cil.oc.api.network.Analyzable
 import li.cil.oc.api.network._
 import li.cil.oc.common.blockentity
 import li.cil.oc.server.PacketSender
-import li.cil.oc.util.{BlockPosition, ItemUtils}
-import li.cil.oc.util.ExtendedLevel._
-import li.cil.oc.util.ExtendedItemStack._
-import net.minecraft.world.item.Item
-import net.minecraft.world.item.Item.Properties
-import net.minecraft.world.item.ItemStack
+import li.cil.oc.util.ItemUtils
 import net.minecraft.core.Direction
-import net.minecraft.Util
 import net.minecraft.core.component.DataComponents
-import net.minecraft.world.entity.player.Player
 import net.minecraft.server.level.ServerPlayer
-import net.minecraft.world.level.Level
-import net.minecraft.world.InteractionResult
-import net.minecraft.world.InteractionResultHolder
+import net.minecraft.world.{InteractionHand, InteractionResult, InteractionResultHolder}
+import net.minecraft.world.entity.player.Player
+import net.minecraft.world.item.{Item, ItemStack}
+import net.minecraft.world.item.Item.Properties
 import net.minecraft.world.item.component.CustomData
+import net.minecraft.world.item.context.UseOnContext
+import net.minecraft.world.level.Level
 import net.neoforged.bus.api.SubscribeEvent
+import net.neoforged.neoforge.common.extensions.IItemExtension
 import net.neoforged.neoforge.common.util.FakePlayer
 import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent
-import net.neoforged.neoforge.common.extensions.IItemExtension
 
 object Analyzer {
   private lazy val analyzer = api.Items.get(Constants.ItemName.Analyzer)
@@ -109,32 +101,42 @@ object Analyzer {
 }
 
 class Analyzer(props: Properties) extends Item(props) with traits.SimpleItem with IItemExtension {
-  override def use(stack: ItemStack, level: Level, player: Player): InteractionResultHolder[ItemStack] = {
+  override def use(level: Level, player: Player, hand: InteractionHand): InteractionResultHolder[ItemStack] = {
+    val stack = player.getItemInHand(hand)
     if (player.isCrouching) {
       CustomData.update(DataComponents.CUSTOM_DATA, stack, data => {
         data.remove(Settings.namespace + "clipboard")
       })
+
+      return InteractionResultHolder.sidedSuccess(stack, level.isClientSide)
     }
 
-    super.use(stack, level, player)
+    super.use(level, player, hand)
   }
 
-  override def onItemUse(stack: ItemStack, player: Player, position: BlockPosition, side: Direction, hitX: Float, hitY: Float, hitZ: Float) = {
-    val world = player.level
-    val tag = ItemUtils.getTag(stack)
-    world.getBlockEntity(position) match {
-      case screen: blockentity.Screen if side == screen.facing =>
-        if (player.isCrouching) {
+  override def useOn(ctx: UseOnContext): InteractionResult = {
+    val world = ctx.getLevel
+    val tag = ItemUtils.getTag(ctx.getItemInHand)
+    val hitX = (ctx.getClickLocation.x - ctx.getClickedPos.getX).toFloat
+    val hitY = (ctx.getClickLocation.y - ctx.getClickedPos.getY).toFloat
+    val hitZ = (ctx.getClickLocation.z - ctx.getClickedPos.getZ).toFloat
+
+    val result = world.getBlockEntity(ctx.getClickedPos) match {
+      case screen: blockentity.Screen if ctx.getClickedFace == screen.facing =>
+        if (ctx.isSecondaryUseActive) {
           screen.copyToAnalyzer(hitX, hitY, hitZ)
         }
         else if (tag != null && tag.contains(Settings.namespace + "clipboard")) {
-          if (!world.isClientSide) {
-            screen.origin.buffer.clipboard(tag.getString(Settings.namespace + "clipboard"), player)
+          if (!world.isClientSide && ctx.getPlayer != null) {
+            screen.origin.buffer.clipboard(tag.getString(Settings.namespace + "clipboard"), ctx.getPlayer)
           }
           true
         }
         else false
-      case _ => Analyzer.analyze(position.world.get.getBlockEntity(position), player, side, hitX, hitY, hitZ)
+      case be if ctx.getPlayer != null => Analyzer.analyze(be, ctx.getPlayer, ctx.getClickedFace, hitX, hitY, hitZ)
+      case _ => false
     }
+
+    if (result) InteractionResult.sidedSuccess(world.isClientSide) else InteractionResult.PASS
   }
 }

--- a/src/main/scala/li/cil/oc/common/item/Chamelium.scala
+++ b/src/main/scala/li/cil/oc/common/item/Chamelium.scala
@@ -1,26 +1,22 @@
 package li.cil.oc.common.item
 
 import li.cil.oc.Settings
-import net.minecraft.world.level.Level
-import net.minecraft.world.item.ItemStack
+import net.minecraft.world.effect.{MobEffectInstance, MobEffects}
 import net.minecraft.world.entity.LivingEntity
-import net.minecraft.world.effect.MobEffectInstance
-import net.minecraft.world.effect.MobEffects
-import net.minecraft.world.item.UseAnim
-import net.minecraft.world.InteractionResultHolder
+import net.minecraft.world.level.Level
 import net.minecraft.world.entity.player.Player
+import net.minecraft.world.item.{Item, ItemStack, UseAnim}
 import net.minecraft.world.item.Item.Properties
-import net.minecraft.world.item.Item
-import net.minecraft.world.InteractionHand
-import net.minecraft.world.InteractionResult
+import net.minecraft.world.{InteractionHand, InteractionResultHolder}
 import net.neoforged.neoforge.common.extensions.IItemExtension
 
 class Chamelium(props: Properties) extends Item(props) with traits.SimpleItem with IItemExtension {
-  override def use(stack: ItemStack, level: Level, player: Player): InteractionResultHolder[ItemStack] = {
+  override def use(level: Level, player: Player, hand: InteractionHand): InteractionResultHolder[ItemStack] = {
     if (Settings.get.chameliumEdible) {
-      player.startUsingItem(if (player.getItemInHand(InteractionHand.MAIN_HAND) == stack) InteractionHand.MAIN_HAND else InteractionHand.OFF_HAND)
+      player.startUsingItem(hand)
     }
-    new InteractionResultHolder(InteractionResult.sidedSuccess(level.isClientSide), stack)
+
+    InteractionResultHolder.sidedSuccess(player.getItemInHand(hand), level.isClientSide)
   }
 
   override def getUseAnimation(stack: ItemStack): UseAnim = UseAnim.EAT

--- a/src/main/scala/li/cil/oc/common/item/DebugCard.scala
+++ b/src/main/scala/li/cil/oc/common/item/DebugCard.scala
@@ -1,21 +1,18 @@
 package li.cil.oc.common.item
 
-import java.util
 import li.cil.oc.Settings
 import li.cil.oc.Settings.DebugCardAccess
 import li.cil.oc.common.item.data.DebugCardData
 import li.cil.oc.server.component.{DebugCard => CDebugCard}
-import net.minecraft.world.item.Item
-import net.minecraft.world.item.Item.Properties
-import net.minecraft.world.item.ItemStack
-import net.minecraft.world.level.Level
-import net.minecraft.world.InteractionResultHolder
-import net.minecraft.world.InteractionResult
-import net.minecraft.world.InteractionHand
 import net.minecraft.network.chat.Component
+import net.minecraft.world.item.Item.Properties
+import net.minecraft.world.item.{Item, ItemStack}
+import net.minecraft.world.level.Level
+import net.minecraft.world.{InteractionHand, InteractionResult, InteractionResultHolder}
 import net.minecraft.world.entity.player.Player
-import net.minecraft.Util
 import net.neoforged.neoforge.common.extensions.IItemExtension
+
+import java.util
 
 class DebugCard(props: Properties) extends Item(props) with traits.ComponentItem with IItemExtension {
 
@@ -25,7 +22,8 @@ class DebugCard(props: Properties) extends Item(props) with traits.ComponentItem
     data.access.foreach(access => tooltip.add(Component.literal(s"§8${access.player}§r")))
   }
 
-  override def use(stack: ItemStack, level: Level, player: Player): InteractionResultHolder[ItemStack] = {
+  override def use(level: Level, player: Player, hand: InteractionHand): InteractionResultHolder[ItemStack] = {
+    val stack = player.getItemInHand(hand)
     if (!level.isClientSide && player.isCrouching) {
       val data = new DebugCardData(stack)
       val name = player.getName
@@ -37,16 +35,15 @@ class DebugCard(props: Properties) extends Item(props) with traits.ComponentItem
             case Some(n) => n
             case None =>
               player.sendSystemMessage(Component.literal("§cYou are not whitelisted to use debug card"))
-              player.swing(InteractionHand.MAIN_HAND)
-              return new InteractionResultHolder[ItemStack](InteractionResult.FAIL, stack)
+              return InteractionResultHolder.sidedSuccess(stack, level.isClientSide)
           }
 
           case _ => ""
         }))
 
       data.saveData(stack)
-      player.swing(InteractionHand.MAIN_HAND)
     }
-    new InteractionResultHolder(InteractionResult.sidedSuccess(level.isClientSide), stack)
+
+    InteractionResultHolder.sidedSuccess(stack, level.isClientSide)
   }
 }

--- a/src/main/scala/li/cil/oc/common/item/Debugger.scala
+++ b/src/main/scala/li/cil/oc/common/item/Debugger.scala
@@ -1,44 +1,29 @@
 package li.cil.oc.common.item
 
-import li.cil.oc.OpenComputers
-import li.cil.oc.api
+import li.cil.oc.{api, OpenComputers}
 import li.cil.oc.api.network._
-import li.cil.oc.util.BlockPosition
-import li.cil.oc.util.ExtendedLevel._
 import net.minecraft.world.item.Item
 import net.minecraft.world.item.Item.Properties
-import net.minecraft.world.item.ItemStack
-import net.minecraft.core.Direction
-import net.minecraft.world.entity.player.Player
-import net.minecraft.server.level.ServerPlayer
-import net.neoforged.neoforge.common.util.FakePlayer
+import net.minecraft.world.InteractionResult
+import net.minecraft.world.item.context.UseOnContext
 import net.neoforged.neoforge.common.extensions.IItemExtension
+import net.neoforged.neoforge.common.util.FakePlayer
 
 class Debugger(props: Properties) extends Item(props) with traits.SimpleItem with IItemExtension {
-  override def onItemUse(stack: ItemStack, player: Player, position: BlockPosition, side: Direction, hitX: Float, hitY: Float, hitZ: Float) = {
-    val world = position.world.get
-    player match {
-      case _: FakePlayer => false // Nope
-      case realPlayer: ServerPlayer =>
-        world.getBlockEntity(position) match {
-          case host: SidedEnvironment =>
-            if (!world.isClientSide) {
-              Debugger.reconnect(Array(host.sidedNode(side)))
-            }
-            true
-          case host: Environment =>
-            if (!world.isClientSide) {
-              Debugger.reconnect(Array(host.node))
-            }
-            true
-          case _ =>
-            if (!world.isClientSide) {
-              Debugger.node.remove()
-            }
-            true
-        }
-      case _ => false
+  override def useOn(ctx: UseOnContext): InteractionResult = {
+    val world = ctx.getLevel
+    if (ctx.getPlayer == null || ctx.getPlayer.isInstanceOf[FakePlayer]) return InteractionResult.FAIL
+
+    world.getBlockEntity(ctx.getClickedPos) match {
+      case host: SidedEnvironment =>
+        if (!world.isClientSide) Debugger.reconnect(Array(host.sidedNode(ctx.getClickedFace)))
+      case host: Environment =>
+        if (!world.isClientSide) Debugger.reconnect(Array(host.node))
+      case _ =>
+        if (!world.isClientSide) Debugger.node.remove()
     }
+
+    InteractionResult.sidedSuccess(world.isClientSide)
   }
 }
 

--- a/src/main/scala/li/cil/oc/common/item/DiskDriveMountable.scala
+++ b/src/main/scala/li/cil/oc/common/item/DiskDriveMountable.scala
@@ -1,21 +1,18 @@
 package li.cil.oc.common.item
 
-import li.cil.oc.OpenComputers
-import li.cil.oc.common.menu.MenuTypes
 import li.cil.oc.common.container.DiskDriveMountableInventory
-import net.minecraft.world.item.Item
-import net.minecraft.world.item.Item.Properties
-import net.minecraft.world.item.ItemStack
-import net.minecraft.world.level.Level
-import net.minecraft.world.entity.player.Player
+import li.cil.oc.common.menu.MenuTypes
 import net.minecraft.server.level.ServerPlayer
-import net.minecraft.world.InteractionHand
-import net.minecraft.world.InteractionResult
-import net.minecraft.world.InteractionResultHolder
+import net.minecraft.world.{InteractionHand, InteractionResultHolder}
+import net.minecraft.world.entity.player.Player
+import net.minecraft.world.item.{Item, ItemStack}
+import net.minecraft.world.item.Item.Properties
+import net.minecraft.world.level.Level
 import net.neoforged.neoforge.common.extensions.IItemExtension
 
 class DiskDriveMountable(props: Properties) extends Item(props) with traits.SimpleItem with IItemExtension {
-  override def use(stack: ItemStack, level: Level, player: Player) = {
+  override def use(level: Level, player: Player, hand: InteractionHand) = {
+    val stack = player.getItemInHand(hand)
     if (!level.isClientSide) player match {
       case srvPlr: ServerPlayer => MenuTypes.openDiskDriveGui(srvPlr, new DiskDriveMountableInventory {
         override def container: ItemStack = stack
@@ -24,7 +21,6 @@ class DiskDriveMountable(props: Properties) extends Item(props) with traits.Simp
       })
       case _ =>
     }
-    player.swing(InteractionHand.MAIN_HAND)
-    new InteractionResultHolder(InteractionResult.sidedSuccess(level.isClientSide), stack)
+    InteractionResultHolder.sidedSuccess(stack, level.isClientSide)
   }
 }

--- a/src/main/scala/li/cil/oc/common/item/Drone.scala
+++ b/src/main/scala/li/cil/oc/common/item/Drone.scala
@@ -4,12 +4,14 @@ import li.cil.oc.client.KeyBindings
 import li.cil.oc.common.entity
 import li.cil.oc.common.item.data.DroneData
 import li.cil.oc.server.agent
-import li.cil.oc.util.{BlockPosition, Tooltip}
-import net.minecraft.core.Direction
+import li.cil.oc.util.Tooltip
 import net.minecraft.network.chat.Component
 import net.minecraft.world.entity.player.Player
-import net.minecraft.world.item.Item.Properties
 import net.minecraft.world.item.{Item, ItemStack}
+import net.minecraft.world.item.Item.Properties
+import net.minecraft.world.item.context.UseOnContext
+import net.minecraft.world.InteractionResult
+import net.minecraft.world.phys.Vec3
 import net.neoforged.neoforge.common.extensions.IItemExtension
 
 import java.util
@@ -24,22 +26,26 @@ class Drone(props: Properties) extends Item(props) with traits.SimpleItem with I
     }
   }
 
-  override def onItemUse(stack: ItemStack, player: Player, position: BlockPosition, side: Direction, hitX: Float, hitY: Float, hitZ: Float) = {
-    val world = position.world.get
+  override def useOn(ctx: UseOnContext): InteractionResult = {
+    val world = ctx.getLevel
     if (!world.isClientSide) {
       val drone = entity.EntityTypes.DRONE.get().create(world)
-      player match {
+      ctx.getPlayer match {
         case fakePlayer: agent.Player =>
           drone.ownerName = fakePlayer.agent.ownerName
           drone.ownerUUID = fakePlayer.agent.ownerUUID
-        case _ =>
+        case player: Player =>
           drone.ownerName = player.getName.getString
           drone.ownerUUID = player.getGameProfile.getId
       }
-      drone.initializeAfterPlacement(stack, player, position.offset(hitX * 1.1f, hitY * 1.1f, hitZ * 1.1f))
+      drone.initializeAfterPlacement(ctx.getItemInHand, new Vec3(
+        ctx.getClickedPos.getX + (ctx.getClickLocation.x - ctx.getClickedPos.getX) * 1.1,
+        ctx.getClickedPos.getY + (ctx.getClickLocation.y - ctx.getClickedPos.getY) * 1.1,
+        ctx.getClickedPos.getZ + (ctx.getClickLocation.z - ctx.getClickedPos.getZ) * 1.1,
+      ))
       world.addFreshEntity(drone)
     }
-    stack.shrink(1)
-    true
+    ctx.getItemInHand.shrink(1)
+    InteractionResult.sidedSuccess(world.isClientSide)
   }
 }

--- a/src/main/scala/li/cil/oc/common/item/EEPROM.scala
+++ b/src/main/scala/li/cil/oc/common/item/EEPROM.scala
@@ -1,17 +1,13 @@
 package li.cil.oc.common.item
 
-import li.cil.oc.Settings
 import li.cil.oc.common.datacomponents.OCComponents
 import li.cil.oc.util.ExtendedDataComponentHolder._
-import li.cil.oc.util.ExtendedItemStack._
-import li.cil.oc.util.{BlockPosition, ItemUtils}
-import net.minecraft.world.item.Item
-import net.minecraft.world.item.Item.Properties
-import net.minecraft.world.item.ItemStack
 import net.minecraft.core.BlockPos
-import net.minecraft.world.level.LevelReader
 import net.minecraft.network.chat.Component
 import net.minecraft.world.entity.player.Player
+import net.minecraft.world.item.Item.Properties
+import net.minecraft.world.item.{Item, ItemStack}
+import net.minecraft.world.level.LevelReader
 import net.neoforged.neoforge.common.extensions.IItemExtension
 
 class EEPROM(props: Properties) extends Item(props) with traits.SimpleItem with IItemExtension {

--- a/src/main/scala/li/cil/oc/common/item/LinkedCard.scala
+++ b/src/main/scala/li/cil/oc/common/item/LinkedCard.scala
@@ -1,23 +1,16 @@
 package li.cil.oc.common.item
 
-import java.util
 import li.cil.oc.Settings
 import li.cil.oc.util.{ItemUtils, Tooltip}
-import li.cil.oc.util.ExtendedItemStack._
-import net.minecraft.world.item.Item
-import net.minecraft.world.item.Item.{Properties, TooltipContext}
-import net.minecraft.world.item.ItemStack
-import net.neoforged.api.distmarker.Dist
-import net.neoforged.api.distmarker.OnlyIn
-
-import scala.collection.convert.ImplicitConversionsToScala._
-import net.minecraft.world.level.Level
 import net.minecraft.network.chat.Component
-import net.minecraft.world.item.TooltipFlag
+import net.minecraft.world.item.{Item, ItemStack, TooltipFlag}
+import net.minecraft.world.item.Item.{Properties, TooltipContext}
 import net.neoforged.neoforge.common.extensions.IItemExtension
 
+import java.util
+import scala.collection.convert.ImplicitConversionsToScala._
+
 class LinkedCard(props: Properties) extends Item(props) with traits.SimpleItem with traits.ItemTier with IItemExtension {
-  @OnlyIn(Dist.CLIENT)
   override def appendHoverText(stack: ItemStack, context: TooltipContext, tooltip: util.List[Component], flag: TooltipFlag): Unit = {
     super.appendHoverText(stack, context, tooltip, flag)
     val tag = ItemUtils.getTag(stack)

--- a/src/main/scala/li/cil/oc/common/item/Manual.scala
+++ b/src/main/scala/li/cil/oc/common/item/Manual.scala
@@ -1,55 +1,45 @@
 package li.cil.oc.common.item
 
-import java.util
-import li.cil.oc.OpenComputers
-import li.cil.oc.api
-import li.cil.oc.util.BlockPosition
-import net.minecraft.world.item.Item.{Properties, TooltipContext}
-import net.minecraft.world.item.{Item, ItemStack, TooltipFlag}
-import net.neoforged.api.distmarker.Dist
-import net.neoforged.api.distmarker.OnlyIn
-import net.minecraft.world.level.Level
+import li.cil.oc.{api, OpenComputers}
 import net.minecraft.network.chat.Component
+import net.minecraft.world.{InteractionHand, InteractionResult, InteractionResultHolder}
 import net.minecraft.world.entity.player.Player
-import net.minecraft.world.InteractionHand
-import net.minecraft.world.InteractionResultHolder
-import net.minecraft.world.InteractionResult
+import net.minecraft.world.item.{Item, ItemStack, TooltipFlag}
+import net.minecraft.world.item.Item.{Properties, TooltipContext}
+import net.minecraft.world.level.Level
 import net.minecraft.ChatFormatting
-import net.minecraft.core.Direction
+import net.minecraft.world.item.context.UseOnContext
 import net.neoforged.neoforge.common.extensions.IItemExtension
 
+import java.util
+
 class Manual(props: Properties) extends Item(props) with traits.SimpleItem with IItemExtension {
-  @OnlyIn(Dist.CLIENT)
   override def appendHoverText(stack: ItemStack, context: TooltipContext, tooltip: util.List[Component], flag: TooltipFlag): Unit = {
     super.appendHoverText(stack, context, tooltip, flag)
     tooltip.add(Component.literal(ChatFormatting.DARK_GRAY.toString + "v" + OpenComputers.Version))
   }
 
-  @Deprecated
-  override def use(level: Level, player: Player, hand: InteractionHand): InteractionResultHolder[ItemStack] =
-    use(player.getItemInHand(hand), level, player)
-
-  override def use(stack: ItemStack, level: Level, player: Player): InteractionResultHolder[ItemStack] = {
+  override def use(level: Level, player: Player, hand: InteractionHand): InteractionResultHolder[ItemStack] = {
     if (level.isClientSide) {
       if (player.isCrouching) {
         api.Manual.reset()
       }
       api.Manual.openFor(player)
     }
-    new InteractionResultHolder(InteractionResult.sidedSuccess(level.isClientSide), stack)
+    InteractionResultHolder.sidedSuccess(player.getItemInHand(hand), level.isClientSide)
   }
 
-  override def onItemUse(stack: ItemStack, player: Player, position: BlockPosition, side: Direction, hitX: Float, hitY: Float, hitZ: Float): Boolean = {
-    val world = player.level
-    api.Manual.pathFor(world, position.toBlockPos) match {
+  override def useOn(ctx: UseOnContext): InteractionResult = {
+    val level = ctx.getLevel
+    api.Manual.pathFor(level, ctx.getClickedPos) match {
       case path: String =>
-        if (world.isClientSide) {
-          api.Manual.openFor(player)
+        if (level.isClientSide && ctx.getPlayer != null) {
+          api.Manual.openFor(ctx.getPlayer)
           api.Manual.reset()
           api.Manual.navigate(path)
         }
-        true
-      case _ => super.onItemUse(stack, player, position, side, hitX, hitY, hitZ)
+        InteractionResult.sidedSuccess(level.isClientSide)
+      case _ => super.useOn(ctx)
     }
   }
 }

--- a/src/main/scala/li/cil/oc/common/item/Nanomachines.scala
+++ b/src/main/scala/li/cil/oc/common/item/Nanomachines.scala
@@ -1,30 +1,22 @@
 package li.cil.oc.common.item
 
-import java.util
 import com.google.common.base.Strings
 import li.cil.oc.api
 import li.cil.oc.common.item.data.NanomachineData
 import li.cil.oc.common.nanomachines.ControllerImpl
 import net.minecraft.core.component.DataComponents
-import li.cil.oc.util.ExtendedItemStack._
-import net.minecraft.world.item.Item
-import net.minecraft.world.item.Item.{Properties, TooltipContext}
-import net.minecraft.world.item.ItemStack
-import net.neoforged.api.distmarker.Dist
-import net.neoforged.api.distmarker.OnlyIn
-import net.minecraft.world.level.Level
 import net.minecraft.network.chat.Component
-import net.minecraft.world.item.TooltipFlag
+import net.minecraft.world.{InteractionHand, InteractionResultHolder}
 import net.minecraft.world.entity.player.Player
-import net.minecraft.world.InteractionResultHolder
-import net.minecraft.world.InteractionResult
-import net.minecraft.world.InteractionHand
-import net.minecraft.world.item.UseAnim
 import net.minecraft.world.entity.LivingEntity
+import net.minecraft.world.item.{Item, ItemStack, TooltipFlag, UseAnim}
+import net.minecraft.world.item.Item.{Properties, TooltipContext}
+import net.minecraft.world.level.Level
 import net.neoforged.neoforge.common.extensions.IItemExtension
 
+import java.util
+
 class Nanomachines(props: Properties) extends Item(props) with traits.SimpleItem with IItemExtension {
-  @OnlyIn(Dist.CLIENT)
   override def appendHoverText(stack: ItemStack, context: TooltipContext, tooltip: util.List[Component], flag: TooltipFlag): Unit = {
     super.appendHoverText(stack, context, tooltip, flag)
     if (stack.has(DataComponents.CUSTOM_DATA)) {
@@ -35,9 +27,9 @@ class Nanomachines(props: Properties) extends Item(props) with traits.SimpleItem
     }
   }
 
-  override def use(stack: ItemStack, level: Level, player: Player): InteractionResultHolder[ItemStack] = {
-    player.startUsingItem(if (player.getItemInHand(InteractionHand.MAIN_HAND) == stack) InteractionHand.MAIN_HAND else InteractionHand.OFF_HAND)
-    new InteractionResultHolder(InteractionResult.sidedSuccess(level.isClientSide), stack)
+  override def use(level: Level, player: Player, hand: InteractionHand): InteractionResultHolder[ItemStack] = {
+    player.startUsingItem(hand)
+    InteractionResultHolder.sidedSuccess(player.getItemInHand(hand), level.isClientSide)
   }
 
   override def getUseAnimation(stack: ItemStack): UseAnim = UseAnim.EAT

--- a/src/main/scala/li/cil/oc/common/item/Present.scala
+++ b/src/main/scala/li/cil/oc/common/item/Present.scala
@@ -1,31 +1,23 @@
 package li.cil.oc.common.item
 
-import java.util.Random
-import li.cil.oc.Constants
-import li.cil.oc.OpenComputers
-import li.cil.oc.api
-import li.cil.oc.util.InventoryUtils
-import li.cil.oc.util.ItemUtils
-import net.minecraft.world.item.Item
-import net.minecraft.world.item.Item.Properties
-import net.minecraft.world.item.ItemStack
-import net.minecraft.world.item.crafting.RecipeManager
-
-import scala.collection.mutable
-import net.minecraft.world.item.CreativeModeTab
-import net.minecraft.core.NonNullList
-import net.minecraft.world.level.Level
+import li.cil.oc.{api, Constants, OpenComputers}
+import li.cil.oc.util.{InventoryUtils, ItemUtils}
+import net.minecraft.sounds.{SoundEvents, SoundSource}
+import net.minecraft.world.{InteractionHand, InteractionResultHolder}
 import net.minecraft.world.entity.player.Player
-import net.minecraft.world.InteractionResultHolder
-import net.minecraft.world.InteractionResult
-import net.minecraft.world.level.block.SoundType
-import net.minecraft.sounds.SoundSource
-import net.minecraft.sounds.SoundEvents
+import net.minecraft.world.item.{Item, ItemStack}
+import net.minecraft.world.item.Item.Properties
+import net.minecraft.world.item.crafting.RecipeManager
+import net.minecraft.world.level.Level
 import net.neoforged.neoforge.common.extensions.IItemExtension
 
+import java.util.Random
+import scala.collection.mutable
+
 class Present(props: Properties) extends Item(props) with traits.SimpleItem with IItemExtension {
-  override def use(stack: ItemStack, level: Level, player: Player): InteractionResultHolder[ItemStack] = {
-    if (stack.getCount > 0) {
+  override def use(level: Level, player: Player, hand: InteractionHand): InteractionResultHolder[ItemStack] = {
+    val stack = player.getItemInHand(hand)
+    if (!stack.isEmpty) {
       stack.shrink(1)
       if (!level.isClientSide) {
         level.playSound(player, player.getX, player.getY, player.getZ, SoundEvents.PLAYER_LEVELUP, SoundSource.MASTER, 0.2f, 1f)
@@ -34,7 +26,7 @@ class Present(props: Properties) extends Item(props) with traits.SimpleItem with
         InventoryUtils.addToPlayerInventory(present, player)
       }
     }
-    new InteractionResultHolder(InteractionResult.sidedSuccess(level.isClientSide), stack)
+    InteractionResultHolder.sidedSuccess(stack, level.isClientSide)
   }
 }
 

--- a/src/main/scala/li/cil/oc/common/item/Server.scala
+++ b/src/main/scala/li/cil/oc/common/item/Server.scala
@@ -52,7 +52,8 @@ class Server(props: Properties, val tier: Int) extends Item(props) with traits.S
     }
   }
 
-  override def use(stack: ItemStack, level: Level, player: Player): InteractionResultHolder[ItemStack] = {
+  override def use(level: Level, player: Player, hand: InteractionHand): InteractionResultHolder[ItemStack] = {
+    val stack = player.getItemInHand(hand)
     if (!player.isCrouching) {
       if (!level.isClientSide) player match {
         case srvPlr: ServerPlayer => MenuTypes.openServerGui(srvPlr, new ServerInventory {
@@ -64,9 +65,8 @@ class Server(props: Properties, val tier: Int) extends Item(props) with traits.S
           }, -1)
         case _ =>
       }
-      player.swing(InteractionHand.MAIN_HAND)
     }
-    new InteractionResultHolder(InteractionResult.sidedSuccess(level.isClientSide), stack)
+    InteractionResultHolder.sidedSuccess(stack, level.isClientSide)
   }
 
 }

--- a/src/main/scala/li/cil/oc/common/item/Tablet.scala
+++ b/src/main/scala/li/cil/oc/common/item/Tablet.scala
@@ -2,34 +2,35 @@ package li.cil.oc.common.item
 
 import com.google.common.cache.{CacheBuilder, RemovalListener, RemovalNotification}
 import com.google.common.collect.ImmutableMap
+import li.cil.oc.{api, client, server, Constants, Localization, OpenComputers, Settings}
+import li.cil.oc.api.{internal, Driver, Machine}
 import li.cil.oc.api.driver.item.Container
 import li.cil.oc.api.machine.MachineHost
 import li.cil.oc.api.network.{Connector, Message, Node}
-import li.cil.oc.api.{Driver, Machine, internal}
-import li.cil.oc.client.{KeyBindings, gui}
+import li.cil.oc.client.{gui, KeyBindings}
+import li.cil.oc.common.{menu, Slot, Tier}
 import li.cil.oc.common.container.ComponentInventory
 import li.cil.oc.common.item.data.TabletData
 import li.cil.oc.common.menu.MenuTypes
-import li.cil.oc.common.{Slot, Tier, menu}
 import li.cil.oc.integration.opencomputers.DriverScreen
 import li.cil.oc.server.component.{Tablet => TabletComponent}
 import li.cil.oc.util._
-import li.cil.oc.{Constants, Localization, OpenComputers, Settings, api, client, server}
 import net.minecraft.client.Minecraft
 import net.minecraft.client.resources.model.ModelResourceLocation
 import net.minecraft.client.server.IntegratedServer
+import net.minecraft.core.{Direction, HolderLookup}
 import net.minecraft.core.component.{DataComponentHolder, DataComponents}
-import net.minecraft.core.{BlockPos, Direction, HolderLookup}
 import net.minecraft.nbt.{CompoundTag, Tag}
 import net.minecraft.network.chat.Component
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.server.level.ServerPlayer
 import net.minecraft.world._
-import net.minecraft.world.entity.player.{Inventory, Player}
 import net.minecraft.world.entity.{Entity, LivingEntity}
+import net.minecraft.world.entity.player.{Inventory, Player}
+import net.minecraft.world.item.{Item, ItemStack}
 import net.minecraft.world.item.Item.Properties
 import net.minecraft.world.item.component.CustomData
-import net.minecraft.world.item.{Item, ItemStack}
+import net.minecraft.world.item.context.UseOnContext
 import net.minecraft.world.level.Level
 import net.neoforged.api.distmarker.{Dist, OnlyIn}
 import net.neoforged.bus.api.SubscribeEvent
@@ -124,23 +125,20 @@ class Tablet(props: Properties) extends Item(props) with traits.SimpleItem with 
       case _ =>
     }
 
-  override def onItemUseFirst(stack: ItemStack, player: Player, level: Level, pos: BlockPos, side: Direction, hitX: Float, hitY: Float, hitZ: Float, hand: InteractionHand): InteractionResult = {
-    Tablet.currentlyAnalyzing = Some((BlockPosition(pos, level), side, hitX, hitY, hitZ))
-    super.onItemUseFirst(stack, player, level, pos, side, hitX, hitY, hitZ, hand)
-  }
-
-  override def onItemUse(stack: ItemStack, player: Player, position: BlockPosition, side: Direction, hitX: Float, hitY: Float, hitZ: Float): Boolean = {
-    player.startUsingItem(if (player.getItemInHand(InteractionHand.MAIN_HAND) == stack) InteractionHand.MAIN_HAND else InteractionHand.OFF_HAND)
-    true
+  override def onItemUseFirst(stack: ItemStack, ctx: UseOnContext): InteractionResult = {
+    Tablet.currentlyAnalyzing = Some((
+      BlockPosition(ctx.getClickedPos, ctx.getLevel), ctx.getClickedFace,
+      (ctx.getClickLocation.x - ctx.getClickedPos.getX).toFloat,
+      (ctx.getClickLocation.y - ctx.getClickedPos.getY).toFloat,
+      (ctx.getClickLocation.z - ctx.getClickedPos.getZ).toFloat
+    ))
+    super.onItemUseFirst(stack, ctx)
   }
 
   @Deprecated
-  override def use(level: Level, player: Player, hand: InteractionHand): InteractionResultHolder[ItemStack] =
-    use(player.getItemInHand(hand), level, player)
-
-  override def use(stack: ItemStack, level: Level, player: Player): InteractionResultHolder[ItemStack] = {
-    player.startUsingItem(if (player.getItemInHand(InteractionHand.MAIN_HAND) == stack) InteractionHand.MAIN_HAND else InteractionHand.OFF_HAND)
-    new InteractionResultHolder(InteractionResult.sidedSuccess(level.isClientSide), stack)
+  override def use(level: Level, player: Player, hand: InteractionHand): InteractionResultHolder[ItemStack] = {
+    player.startUsingItem(hand)
+    InteractionResultHolder.sidedSuccess(player.getItemInHand(hand), level.isClientSide)
   }
 
   override def getUseDuration(stack: ItemStack, entity: LivingEntity): Int = 72000

--- a/src/main/scala/li/cil/oc/common/item/Terminal.scala
+++ b/src/main/scala/li/cil/oc/common/item/Terminal.scala
@@ -1,33 +1,24 @@
 package li.cil.oc.common.item
 
-import java.util
 import com.google.common.base.Strings
-import li.cil.oc.Constants
-import li.cil.oc.Localization
-import li.cil.oc.Settings
-import li.cil.oc.api
-import li.cil.oc.client.{Textures, gui}
-import li.cil.oc.common.blockentity
-import li.cil.oc.common.component
+import li.cil.oc.{api, Localization}
+import li.cil.oc.client.gui
+import li.cil.oc.common.{blockentity, component}
 import li.cil.oc.common.blockentity.traits.BaseBlockEntity
 import li.cil.oc.common.datacomponents.{OCComponents, TerminalReference}
-import li.cil.oc.util.ItemUtils
-import li.cil.oc.util.ExtendedItemStack._
 import li.cil.oc.util.ExtendedDataComponentHolder._
 import net.minecraft.client.Minecraft
-import net.neoforged.api.distmarker.Dist
-import net.neoforged.api.distmarker.OnlyIn
-import net.minecraft.world.item.Item
-import net.minecraft.world.item.Item.{Properties, TooltipContext}
-import net.minecraft.world.item.ItemStack
-import net.minecraft.world.level.{Level, LevelReader}
-import net.minecraft.network.chat.Component
-import net.minecraft.world.item.TooltipFlag
-import net.minecraft.world.entity.player.Player
-import net.minecraft.world.InteractionResultHolder
-import net.minecraft.world.InteractionHand
 import net.minecraft.core.BlockPos
+import net.minecraft.network.chat.Component
+import net.minecraft.world.{InteractionHand, InteractionResultHolder}
+import net.minecraft.world.entity.player.Player
+import net.minecraft.world.item.{Item, ItemStack, TooltipFlag}
+import net.minecraft.world.item.Item.{Properties, TooltipContext}
+import net.minecraft.world.level.{Level, LevelReader}
+import net.neoforged.api.distmarker.{Dist, OnlyIn}
 import net.neoforged.neoforge.common.extensions.IItemExtension
+
+import java.util
 
 class Terminal(props: Properties) extends Item(props) with traits.SimpleItem with IItemExtension {
   def hasServer(stack: ItemStack) = stack.has(OCComponents.TERMINAL_REFERENCE)
@@ -41,19 +32,17 @@ class Terminal(props: Properties) extends Item(props) with traits.SimpleItem wit
     }
   }
 
-  @OnlyIn(Dist.CLIENT)
   override def appendHoverText(stack: ItemStack, context: TooltipContext, tooltip: util.List[Component], flag: TooltipFlag): Unit = {
     super.appendHoverText(stack, context, tooltip, flag)
-    for(data <- stack.getComponent(OCComponents.TERMINAL_REFERENCE)) {
+    for (data <- stack.getComponent(OCComponents.TERMINAL_REFERENCE)) {
       tooltip.add(Component.literal("§8" + data.server.substring(0, 13) + "...§7"))
     }
   }
 
-  //@OnlyIn(Dist.CLIENT)
 
-
-  override def use(stack: ItemStack, level: Level, player: Player): InteractionResultHolder[ItemStack] = {
-    for(TerminalReference(key, server) <- stack.getComponent(OCComponents.TERMINAL_REFERENCE) if !player.isCrouching) {
+  override def use(level: Level, player: Player, hand: InteractionHand): InteractionResultHolder[ItemStack] = {
+    val stack = player.getItemInHand(hand)
+    for (TerminalReference(key, server) <- stack.getComponent(OCComponents.TERMINAL_REFERENCE) if !player.isCrouching) {
       if (key.nonEmpty && server.nonEmpty) {
         if (level.isClientSide) {
           if (!Strings.isNullOrEmpty(key) && !Strings.isNullOrEmpty(server)) {
@@ -61,6 +50,7 @@ class Terminal(props: Properties) extends Item(props) with traits.SimpleItem wit
               case Some(term) if term != null && term.rack != null => term.rack match {
                 case rack: BaseBlockEntity with api.internal.Rack => {
                   def inRange = player.isAlive && !rack.isRemoved && player.distanceToSqr(rack.x + 0.5, rack.y + 0.5, rack.z + 0.5) < term.range * term.range
+
                   if (inRange) {
                     if (term.sidedKeys.contains(key)) showGui(stack, key, term, () => inRange)
                     else player.displayClientMessage(Localization.Terminal.InvalidKey, true)
@@ -73,10 +63,10 @@ class Terminal(props: Properties) extends Item(props) with traits.SimpleItem wit
             }
           }
         }
-        player.swing(InteractionHand.MAIN_HAND)
       }
     }
-    super.use(stack, level, player)
+
+    InteractionResultHolder.sidedSuccess(stack, level.isClientSide)
   }
 
   @OnlyIn(Dist.CLIENT)
@@ -85,6 +75,7 @@ class Terminal(props: Properties) extends Item(props) with traits.SimpleItem wit
       case buffer: component.TextBuffer => buffer.requestSynchronization()
       case _ =>
     }
+
     def remainsUsable(): Boolean = {
       // Check if someone else bound a term to our server.
       if (!stack.getComponent(OCComponents.TERMINAL_REFERENCE).exists(_.key == key) || !term.sidedKeys.contains(key)) Minecraft.getInstance.popGuiLayer

--- a/src/main/scala/li/cil/oc/common/item/TexturePicker.scala
+++ b/src/main/scala/li/cil/oc/common/item/TexturePicker.scala
@@ -1,33 +1,26 @@
 package li.cil.oc.common.item
 
 import li.cil.oc.Localization
-import li.cil.oc.util.BlockPosition
-import li.cil.oc.util.ExtendedLevel._
-import net.minecraft.world.level.block.Block
 import net.minecraft.client.Minecraft
 import net.minecraft.world.item.Item
 import net.minecraft.world.item.Item.Properties
-import net.minecraft.world.item.ItemStack
-import net.minecraft.core.Direction
-import net.minecraft.world.entity.player.Player
-import net.minecraft.Util
+import net.minecraft.world.item.context.UseOnContext
+import net.minecraft.world.InteractionResult
+import net.neoforged.neoforge.client.model.data.ModelData
 import net.neoforged.neoforge.common.extensions.IItemExtension
 
 class TexturePicker(props: Properties) extends Item(props) with traits.SimpleItem with IItemExtension {
-  override def onItemUse(stack: ItemStack, player: Player, position: BlockPosition, side: Direction, hitX: Float, hitY: Float, hitZ: Float): Boolean = {
-    player.level.getBlock(position) match {
-      case block: Block =>
-        if (player.level.isClientSide) {
-          val pos = position.toBlockPos
-          val model = Minecraft.getInstance.getBlockRenderer.getBlockModel(player.level.getBlockState(pos))
-          val be = player.level.getBlockEntity(pos)
-          val particle = if (model != null) model.getParticleIcon(be.getModelData) else null
-          if (particle != null && particle.contents.name != null) {
-            player.sendSystemMessage(Localization.Chat.TextureName(particle.contents.name.toString))
-          }
-        }
-        true
-      case _ => super.onItemUse(stack, player, position, side, hitX, hitY, hitZ)
+  override def useOn(ctx: UseOnContext): InteractionResult = {
+    if (ctx.getLevel.isClientSide) {
+      val pos = ctx.getClickedPos
+      val model = Minecraft.getInstance.getBlockRenderer.getBlockModel(ctx.getLevel.getBlockState(ctx.getClickedPos))
+      val be = ctx.getLevel.getBlockEntity(pos)
+      val particle = model.getParticleIcon(if (be == null) ModelData.EMPTY else be.getModelData)
+      if (ctx.getPlayer != null) {
+        ctx.getPlayer.sendSystemMessage(Localization.Chat.TextureName(particle.contents.name.toString))
+      }
     }
+
+    InteractionResult.sidedSuccess(ctx.getLevel.isClientSide)
   }
 }

--- a/src/main/scala/li/cil/oc/common/item/UpgradeDatabase.scala
+++ b/src/main/scala/li/cil/oc/common/item/UpgradeDatabase.scala
@@ -1,20 +1,15 @@
 package li.cil.oc.common.item
 
-import li.cil.oc.OpenComputers
 import li.cil.oc.Settings
 import li.cil.oc.common.container.DatabaseInventory
 import li.cil.oc.common.menu.MenuTypes
 import net.minecraft.core.component.DataComponents
-import li.cil.oc.util.ExtendedItemStack._
-import net.minecraft.world.item.Item.Properties
-import net.minecraft.world.item.Item
-import net.minecraft.world.item.ItemStack
-import net.minecraft.world.level.Level
-import net.minecraft.world.entity.player.Player
-import net.minecraft.world.InteractionResultHolder
 import net.minecraft.server.level.ServerPlayer
-import net.minecraft.world.InteractionHand
-import net.minecraft.world.InteractionResult
+import net.minecraft.world.entity.player.Player
+import net.minecraft.world.item.Item.Properties
+import net.minecraft.world.item.{Item, ItemStack}
+import net.minecraft.world.level.Level
+import net.minecraft.world.{InteractionHand, InteractionResultHolder}
 import net.minecraft.world.item.component.CustomData
 import net.neoforged.neoforge.common.extensions.IItemExtension
 
@@ -24,24 +19,23 @@ class UpgradeDatabase(props: Properties, val tier: Int) extends Item(props) with
 
   override protected def tooltipData = Seq(Settings.get.databaseEntriesPerTier(tier))
 
-  override def use(stack: ItemStack, level: Level, player: Player): InteractionResultHolder[ItemStack] = {
+  override def use(level: Level, player: Player, hand: InteractionHand): InteractionResultHolder[ItemStack] = {
+    val stack = player.getItemInHand(hand)
     if (!player.isCrouching) {
       if (!level.isClientSide) player match {
         case srvPlr: ServerPlayer => MenuTypes.openDatabaseGui(srvPlr, new DatabaseInventory {
-            override def container = stack
+          override def container = stack
 
-            override def stillValid(player: Player) = player == srvPlr
-          })
+          override def stillValid(player: Player) = player == srvPlr
+        })
         case _ =>
       }
-      player.swing(InteractionHand.MAIN_HAND)
     }
     else {
       CustomData.update(DataComponents.CUSTOM_DATA, stack, data => {
         data.remove(Settings.namespace + "items")
       })
-      player.swing(InteractionHand.MAIN_HAND)
     }
-    new InteractionResultHolder(InteractionResult.sidedSuccess(level.isClientSide), stack)
+    InteractionResultHolder.sidedSuccess(stack, level.isClientSide)
   }
 }

--- a/src/main/scala/li/cil/oc/common/item/UpgradeExperience.scala
+++ b/src/main/scala/li/cil/oc/common/item/UpgradeExperience.scala
@@ -1,22 +1,16 @@
 package li.cil.oc.common.item
 
-import java.util
 import li.cil.oc.Localization
-import li.cil.oc.util.Tooltip
-import li.cil.oc.util.ExtendedItemStack._
-import li.cil.oc.util.{UpgradeExperience => ExperienceUtil}
+import li.cil.oc.util.{Tooltip, UpgradeExperience => ExperienceUtil}
 import net.minecraft.core.component.DataComponents
-import net.minecraft.world.item.Item
-import net.minecraft.world.item.Item.{Properties, TooltipContext}
-import net.minecraft.world.item.ItemStack
-import net.neoforged.api.distmarker.{Dist, OnlyIn}
-import net.minecraft.world.item.TooltipFlag
-import net.minecraft.world.level.Level
 import net.minecraft.network.chat.Component
+import net.minecraft.world.item.Item.{Properties, TooltipContext}
+import net.minecraft.world.item.{Item, ItemStack, TooltipFlag}
 import net.neoforged.neoforge.common.extensions.IItemExtension
 
+import java.util
+
 class UpgradeExperience(props: Properties) extends Item(props) with traits.SimpleItem with traits.ItemTier with IItemExtension {
-  @OnlyIn(Dist.CLIENT)
   override def appendHoverText(stack: ItemStack, context: TooltipContext, tooltip: util.List[Component], flag: TooltipFlag): Unit = {
     super.appendHoverText(stack, context, tooltip, flag)
     if (stack.has(DataComponents.CUSTOM_DATA)) {

--- a/src/main/scala/li/cil/oc/common/item/UpgradeMF.scala
+++ b/src/main/scala/li/cil/oc/common/item/UpgradeMF.scala
@@ -1,31 +1,26 @@
 package li.cil.oc.common.item
 
-import java.util
 import li.cil.oc.Localization
-import li.cil.oc.Settings
 import li.cil.oc.common.datacomponents.{MFCoords, OCComponents}
 import li.cil.oc.util.Tooltip
-import li.cil.oc.util.ExtendedItemStack._
-import net.minecraft.world.item.Item
-import net.minecraft.world.item.Item.Properties
-import net.minecraft.world.item.ItemStack
-import net.minecraft.world.entity.player.Player
-import net.minecraft.world.level.Level
-import net.minecraft.core.BlockPos
-import net.minecraft.core.Direction
-import net.minecraft.world.InteractionHand
-import net.minecraft.world.InteractionResult
 import net.minecraft.network.chat.Component
-import net.minecraft.nbt.CompoundTag
+import net.minecraft.world.item.{Item, ItemStack}
+import net.minecraft.world.item.Item.Properties
+import net.minecraft.world.InteractionResult
+import net.minecraft.world.item.context.UseOnContext
 import net.neoforged.neoforge.common.extensions.IItemExtension
 
+import java.util
+
 class UpgradeMF(props: Properties) extends Item(props) with traits.SimpleItem with traits.ItemTier with IItemExtension {
-  override def onItemUseFirst(stack: ItemStack, player: Player, level: Level, pos: BlockPos, side: Direction, hitX: Float, hitY: Float, hitZ: Float, hand: InteractionHand): InteractionResult = {
-    if (!player.level.isClientSide && player.isCrouching) {
-      stack.set(OCComponents.MF_COORD, MFCoords(level.dimension.location, pos, side))
-      return InteractionResult.sidedSuccess(player.level.isClientSide)
+  override def onItemUseFirst(stack: ItemStack, ctx: UseOnContext): InteractionResult = {
+    val level = ctx.getLevel
+    if (!level.isClientSide && ctx.isSecondaryUseActive) {
+      stack.set(OCComponents.MF_COORD, MFCoords(level.dimension.location, ctx.getClickedPos, ctx.getClickedFace))
+      return InteractionResult.sidedSuccess(level.isClientSide)
     }
-    super.onItemUseFirst(stack, player, level, pos, side, hitX, hitY, hitZ, hand)
+
+    super.onItemUseFirst(stack, ctx)
   }
 
   override protected def tooltipExtended(stack: ItemStack, tooltip: util.List[Component]): Unit = {

--- a/src/main/scala/li/cil/oc/common/item/UpgradeTank.scala
+++ b/src/main/scala/li/cil/oc/common/item/UpgradeTank.scala
@@ -1,24 +1,17 @@
 package li.cil.oc.common.item
 
-import java.util
 import li.cil.oc.Settings
 import li.cil.oc.util.Tooltip
-import li.cil.oc.util.ExtendedItemStack._
 import net.minecraft.core.component.DataComponents
-import net.minecraft.world.item.Item
-import net.minecraft.world.item.Item.{Properties, TooltipContext}
-import net.minecraft.world.item.ItemStack
-import net.neoforged.neoforge.fluids.FluidStack
-import net.neoforged.api.distmarker.Dist
-import net.neoforged.api.distmarker.OnlyIn
-import net.minecraft.nbt.NbtOps
 import net.minecraft.network.chat.Component
-import net.minecraft.world.item.TooltipFlag
-import net.minecraft.world.level.Level
+import net.minecraft.world.item.Item.{Properties, TooltipContext}
+import net.minecraft.world.item.{Item, ItemStack, TooltipFlag}
 import net.neoforged.neoforge.common.extensions.IItemExtension
+import net.neoforged.neoforge.fluids.FluidStack
+
+import java.util
 
 class UpgradeTank(props: Properties) extends Item(props) with traits.SimpleItem with traits.ItemTier with IItemExtension {
-  @OnlyIn(Dist.CLIENT)
   override def appendHoverText(stack: ItemStack, context: TooltipContext, tooltip: util.List[Component], flag: TooltipFlag): Unit = {
     super.appendHoverText(stack, context, tooltip, flag)
     if (stack.has(DataComponents.CUSTOM_DATA)) {

--- a/src/main/scala/li/cil/oc/common/item/Wrench.scala
+++ b/src/main/scala/li/cil/oc/common/item/Wrench.scala
@@ -2,39 +2,39 @@ package li.cil.oc.common.item
 
 import li.cil.oc.api
 import li.cil.oc.common.block.SimpleBlock
-import net.minecraft.core.{BlockPos, Direction}
+import net.minecraft.core.BlockPos
+import net.minecraft.world.{InteractionHand, InteractionResult}
 import net.minecraft.world.entity.player.Player
 import net.minecraft.world.item.{Item, ItemStack}
-import net.minecraft.world.level.block.Rotation
-import net.minecraft.world.level.{BlockGetter, Level, LevelReader}
-import net.minecraft.world.{InteractionHand, InteractionResult}
-import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent
 import net.minecraft.world.item.Item.Properties
-import net.minecraft.world.level.block.Blocks
+import net.minecraft.world.item.context.UseOnContext
+import net.minecraft.world.level.{Level, LevelReader}
+import net.minecraft.world.level.block.{Block, Rotation}
 import net.neoforged.neoforge.common.extensions.IItemExtension
 
 class Wrench(props: Properties) extends Item(props) with traits.SimpleItem with api.internal.Wrench with IItemExtension {
   override def doesSneakBypassUse(stack: ItemStack, world: LevelReader, pos: BlockPos, player: Player): Boolean = true
 
-  override def onItemUseFirst(stack: ItemStack, player: Player, world: Level, pos: BlockPos, side: Direction, hitX: Float, hitY: Float, hitZ: Float, hand: InteractionHand): InteractionResult = {
-    if (world.isLoaded(pos) && world.mayInteract(player, pos)) {
+  override def onItemUseFirst(stack: ItemStack, ctx: UseOnContext): InteractionResult = {
+    val world = ctx.getLevel
+    val pos = ctx.getClickedPos
+    val player = ctx.getPlayer
+    if (player != null && world.isLoaded(pos) && world.mayInteract(player, pos)) {
       val state = world.getBlockState(pos)
       state.getBlock match {
-        case block: SimpleBlock if block.rotateBlock(world, pos, side) =>
+        case block: SimpleBlock if block.rotateBlock(world, pos, ctx.getClickedFace) =>
           state.onNeighborChange(world, pos, pos)
-          player.swing(hand)
-          if (!world.isClientSide) InteractionResult.sidedSuccess(world.isClientSide) else InteractionResult.PASS
+          InteractionResult.sidedSuccess(world.isClientSide)
         case _ =>
           val updated = state.rotate(world, pos, Rotation.CLOCKWISE_90)
           if (updated != state) {
-            world.setBlock(pos, updated, 3)
-            player.swing(hand)
-            if (!world.isClientSide) InteractionResult.sidedSuccess(world.isClientSide) else InteractionResult.PASS
+            world.setBlock(pos, updated, Block.UPDATE_ALL)
+            InteractionResult.sidedSuccess(world.isClientSide)
           }
-          else super.onItemUseFirst(stack, player, world, pos, side, hitX, hitY, hitZ, hand)
+          else super.onItemUseFirst(stack, ctx)
       }
     }
-    else super.onItemUseFirst(stack, player, world, pos, side, hitX, hitY, hitZ, hand)
+    else super.onItemUseFirst(stack, ctx)
   }
 
   def useWrenchOnBlock(player: Player, world: Level, pos: BlockPos, simulate: Boolean): Boolean = {

--- a/src/main/scala/li/cil/oc/common/item/data/NavigationUpgradeData.scala
+++ b/src/main/scala/li/cil/oc/common/item/data/NavigationUpgradeData.scala
@@ -1,23 +1,14 @@
 package li.cil.oc.common.item.data
 
 import li.cil.oc.Constants
-import li.cil.oc.Settings
 import li.cil.oc.api.ImmutableItemStack
 import li.cil.oc.common.datacomponents.OCComponents
-import li.cil.oc.util.ExtendedNBT._
-import li.cil.oc.util.ExtendedItemStack._
 import li.cil.oc.util.ExtendedDataComponentHolder._
-import li.cil.oc.util.ItemUtils
-import net.minecraft.core.HolderLookup
-import net.minecraft.core.component.{DataComponentHolder, DataComponents}
-import net.minecraft.world.item.{ItemStack, Items, MapItem}
+import net.minecraft.core.component.DataComponentHolder
+import net.minecraft.world.item.{Items, ItemStack, MapItem}
 import net.minecraft.world.level.Level
-import net.minecraft.nbt.CompoundTag
-import net.minecraft.nbt.NbtOps
-import net.minecraft.world.item.component.CustomData
 import net.minecraft.world.level.saveddata.maps.MapItemSavedData
 import net.neoforged.neoforge.common.MutableDataComponentHolder
-import net.neoforged.neoforge.server.ServerLifecycleHooks
 
 class NavigationUpgradeData extends ItemData(Constants.ItemName.NavigationUpgrade) {
   def this(stack: DataComponentHolder) = {
@@ -45,7 +36,7 @@ class NavigationUpgradeData extends ItemData(Constants.ItemName.NavigationUpgrad
   }
 
   override def saveData(holder: MutableDataComponentHolder): Unit = {
-    if(map != null) {
+    if (map != null) {
       holder.setComponent(OCComponents.SOURCE_MAP_ITEM, ImmutableItemStack.copyOf(map))
     }
   }

--- a/src/main/scala/li/cil/oc/common/item/traits/CPULike.scala
+++ b/src/main/scala/li/cil/oc/common/item/traits/CPULike.scala
@@ -1,23 +1,17 @@
 package li.cil.oc.common.item.traits
 
-import java.util
-
-import li.cil.oc.Settings
-import li.cil.oc.api
+import li.cil.oc.{api, Settings}
 import li.cil.oc.api.driver.item.MutableProcessor
 import li.cil.oc.integration.opencomputers.DriverCPU
 import li.cil.oc.util.Tooltip
-
-import scala.collection.convert.ImplicitConversionsToScala._
-import scala.language.existentials
-import net.minecraft.world.item.ItemStack
 import net.minecraft.network.chat.Component
-import net.minecraft.world.level.Level
+import net.minecraft.world.{InteractionHand, InteractionResultHolder}
 import net.minecraft.world.entity.player.Player
-import net.minecraft.world.InteractionResultHolder
-import net.minecraft.world.InteractionResult
-import net.minecraft.world.InteractionHand
-import net.minecraft.Util
+import net.minecraft.world.item.ItemStack
+import net.minecraft.world.level.Level
+
+import java.util
+import scala.jdk.CollectionConverters._
 
 trait CPULike extends SimpleItem {
   def cpuTier: Int
@@ -25,17 +19,18 @@ trait CPULike extends SimpleItem {
   override protected def tooltipData: Seq[Any] = Seq(Settings.get.cpuComponentSupport(cpuTier))
 
   override protected def tooltipExtended(stack: ItemStack, tooltip: util.List[Component]): Unit = {
-    for (curr <- Tooltip.get("cpu.Architecture", api.Machine.getArchitectureName(DriverCPU.architecture(stack)))) {
+    for (curr <- Tooltip.get("cpu.Architecture", api.Machine.getArchitectureName(DriverCPU.architecture(stack))).asScala) {
       tooltip.add(Component.literal(curr).setStyle(Tooltip.DefaultStyle))
     }
   }
 
-  override def use(stack: ItemStack, level: Level, player: Player): InteractionResultHolder[ItemStack] = {
+  override def use(level: Level, player: Player, hand: InteractionHand): InteractionResultHolder[ItemStack] = {
+    val stack = player.getItemInHand(hand)
     if (!player.isCrouching) {
       if (!level.isClientSide) {
         api.Driver.driverFor(stack) match {
           case driver: MutableProcessor =>
-            val architectures = driver.allArchitectures.toList
+            val architectures = driver.allArchitectures.asScala.toList
             if (architectures.nonEmpty) {
               val currentIndex = architectures.indexOf(driver.architecture(stack))
               val newIndex = (currentIndex + 1) % architectures.length
@@ -44,11 +39,11 @@ trait CPULike extends SimpleItem {
               driver.setArchitecture(stack, archClass)
               player.displayClientMessage(Component.translatable(Settings.namespace + "tooltip.cpu.Architecture", archName), true)
             }
-            player.swing(InteractionHand.MAIN_HAND)
           case _ => // No known driver for this processor.
         }
       }
     }
-    new InteractionResultHolder(InteractionResult.sidedSuccess(level.isClientSide), stack)
+
+    InteractionResultHolder.sidedSuccess(stack, level.isClientSide)
   }
 }

--- a/src/main/scala/li/cil/oc/common/item/traits/ComponentItem.scala
+++ b/src/main/scala/li/cil/oc/common/item/traits/ComponentItem.scala
@@ -1,14 +1,13 @@
 package li.cil.oc.common.item.traits
 
 import net.minecraft.network.chat.Component
-import net.minecraft.world.{InteractionHand, InteractionResult, InteractionResultHolder}
+import net.minecraft.world.{InteractionHand, InteractionResultHolder}
 import net.minecraft.world.entity.player.Player
 import net.minecraft.world.item.{Item, ItemStack}
 import net.minecraft.world.level.Level
 
 /** Adds the double-sneak gesture for resetting an item's component identity. */
 trait ComponentItem extends SimpleItem {
-  @Deprecated
   override def use(world: Level, player: Player, hand: InteractionHand): InteractionResultHolder[ItemStack] =
     player.getItemInHand(hand) match {
       case stack: ItemStack if player.isShiftKeyDown =>
@@ -24,9 +23,8 @@ trait ComponentItem extends SimpleItem {
             player.displayClientMessage(Component.literal("Double click quickly to reset"), true)
           }
         }
-        new InteractionResultHolder(InteractionResult.sidedSuccess(world.isClientSide), resultStack)
+        InteractionResultHolder.sidedSuccess(resultStack, world.isClientSide)
 
-      case stack: ItemStack => use(stack, world, player)
       case _ => super.use(world, player, hand)
     }
 }

--- a/src/main/scala/li/cil/oc/common/item/traits/FileSystemLike.scala
+++ b/src/main/scala/li/cil/oc/common/item/traits/FileSystemLike.scala
@@ -1,33 +1,26 @@
 package li.cil.oc.common.item.traits
 
-import java.util
-import li.cil.oc.Localization
-import li.cil.oc.OpenComputers
-import li.cil.oc.Settings
+import li.cil.oc.{Localization, Settings}
 import li.cil.oc.client.gui
 import li.cil.oc.common.datacomponents.OCComponents
 import li.cil.oc.common.item.data.DriveData
-import li.cil.oc.util.ExtendedItemStack._
 import li.cil.oc.util.{ItemUtils, Tooltip}
 import net.minecraft.client.Minecraft
-import net.neoforged.api.distmarker.Dist
-import net.neoforged.api.distmarker.OnlyIn
-import net.minecraft.world.level.Level
-import net.minecraft.world.item.ItemStack
 import net.minecraft.network.chat.Component
-import net.minecraft.world.item.TooltipFlag
+import net.minecraft.world.{InteractionHand, InteractionResultHolder}
 import net.minecraft.world.entity.player.Player
-import net.minecraft.world.InteractionResultHolder
-import net.minecraft.world.InteractionHand
-import net.minecraft.world.InteractionResult
+import net.minecraft.world.item.{ItemStack, TooltipFlag}
 import net.minecraft.world.item.Item.TooltipContext
+import net.minecraft.world.level.Level
+import net.neoforged.api.distmarker.{Dist, OnlyIn}
+
+import java.util
 
 trait FileSystemLike extends SimpleItem {
   override protected def tooltipName = None
 
   def kiloBytes: Int
 
-  @OnlyIn(Dist.CLIENT)
   override def appendHoverText(stack: ItemStack, context: TooltipContext, tooltip: util.List[Component], flag: TooltipFlag): Unit = {
     super.appendHoverText(stack, context, tooltip, flag)
     val nbt = ItemUtils.getTag(stack)
@@ -52,13 +45,14 @@ trait FileSystemLike extends SimpleItem {
     }
   }
 
-  override def use(stack: ItemStack, level: Level, player: Player): InteractionResultHolder[ItemStack] = {
+  override def use(level: Level, player: Player, hand: InteractionHand): InteractionResultHolder[ItemStack] = {
+    val stack = player.getItemInHand(hand)
     val tag = ItemUtils.getTag(stack)
     if (!player.isCrouching && (tag == null || !stack.has(OCComponents.LOOT_DISK))) {
       if (level.isClientSide) showGui(stack, player)
-      player.swing(InteractionHand.MAIN_HAND)
     }
-    new InteractionResultHolder(InteractionResult.sidedSuccess(level.isClientSide), stack)
+
+    InteractionResultHolder.sidedSuccess(stack, level.isClientSide)
   }
 
   @OnlyIn(Dist.CLIENT)

--- a/src/main/scala/li/cil/oc/common/item/traits/ItemTier.scala
+++ b/src/main/scala/li/cil/oc/common/item/traits/ItemTier.scala
@@ -1,17 +1,14 @@
 package li.cil.oc.common.item.traits
 
-import java.util
 import li.cil.oc.Localization
 import li.cil.oc.util.Tooltip
-import net.neoforged.api.distmarker.{Dist, OnlyIn}
-import net.minecraft.world.level.Level
-import net.minecraft.world.item.ItemStack
 import net.minecraft.network.chat.Component
 import net.minecraft.world.item.Item.TooltipContext
-import net.minecraft.world.item.TooltipFlag
+import net.minecraft.world.item.{ItemStack, TooltipFlag}
+
+import java.util
 
 trait ItemTier extends SimpleItem {
-  @OnlyIn(Dist.CLIENT)
   override def appendHoverText(stack: ItemStack, context: TooltipContext, tooltip: util.List[Component], flag: TooltipFlag): Unit = {
     super.appendHoverText(stack, context, tooltip, flag)
     if (flag.isAdvanced) {

--- a/src/main/scala/li/cil/oc/common/item/traits/SimpleItem.scala
+++ b/src/main/scala/li/cil/oc/common/item/traits/SimpleItem.scala
@@ -1,37 +1,26 @@
 package li.cil.oc.common.item.traits
 
-import java.util
-
-import li.cil.oc.Settings
+import com.mojang.blaze3d.vertex.PoseStack
 import li.cil.oc.api
 import li.cil.oc.api.event.RobotRenderEvent.MountPoint
 import li.cil.oc.api.internal.Robot
 import li.cil.oc.client.renderer.item.ItemUpgradeRenderer
 import li.cil.oc.common.blockentity
-import li.cil.oc.util.{BlockPosition, ClientAccessHelper, ItemUtils, Rarity, Tooltip}
-import net.minecraft.world.item.ItemStack
-import net.minecraft.world.level.LevelReader
-import net.minecraft.core.Direction
-import net.minecraft.world.{InteractionHand, InteractionResult, InteractionResultHolder, item}
-import net.minecraft.core.BlockPos
-import net.minecraft.world.entity.player.Player
-import net.minecraft.world.item.Item
-import net.minecraft.world.item.context.UseOnContext
-import net.minecraft.world.level.Level
-import net.minecraft.client.renderer.MultiBufferSource
-import net.minecraft.network.chat.Component
-import net.minecraft.world.item.TooltipFlag
-import net.neoforged.api.distmarker.Dist
-import net.neoforged.api.distmarker.OnlyIn
-
-import scala.collection.convert.ImplicitConversionsToScala._
-import com.mojang.blaze3d.vertex.PoseStack
-import li.cil.oc.common.item.data.TabletData
-import li.cil.oc.util.ExtendedDataComponentHolder._
-import net.minecraft.core.component.DataComponents
-import net.minecraft.world.item.Item.TooltipContext
-import net.neoforged.neoforge.common.extensions.IItemExtension
 import li.cil.oc.common.datacomponents.OCComponents
+import li.cil.oc.util.ExtendedDataComponentHolder._
+import li.cil.oc.util.Tooltip
+import net.minecraft.client.renderer.MultiBufferSource
+import net.minecraft.core.BlockPos
+import net.minecraft.network.chat.Component
+import net.minecraft.world.entity.player.Player
+import net.minecraft.world.item.{Item, ItemStack, TooltipFlag}
+import net.minecraft.world.item.Item.TooltipContext
+import net.minecraft.world.level.LevelReader
+import net.neoforged.api.distmarker.{Dist, OnlyIn}
+import net.neoforged.neoforge.common.extensions.IItemExtension
+
+import java.util
+import scala.collection.convert.ImplicitConversionsToScala._
 
 trait SimpleItem extends Item with api.driver.item.UpgradeRenderer with IItemExtension {
   def createItemStack(amount: Int = 1) = new ItemStack(this, amount)
@@ -49,40 +38,6 @@ trait SimpleItem extends Item with api.driver.item.UpgradeRenderer with IItemExt
     }
   }
 
-  @Deprecated
-  override def onItemUseFirst(stack: ItemStack, ctx: UseOnContext): InteractionResult = {
-    val pos = ctx.getClickedPos
-    val hitPos = ctx.getClickLocation
-    onItemUseFirst(stack, ctx.getPlayer, ctx.getPlayer.level, pos, ctx.getClickedFace,
-      (hitPos.x - pos.getX).toFloat, (hitPos.y - pos.getY).toFloat, (hitPos.z - pos.getZ).toFloat, ctx.getHand)
-  }
-
-  @Deprecated
-  def onItemUseFirst(stack: ItemStack, player: Player, level: Level, pos: BlockPos, side: Direction, hitX: Float, hitY: Float, hitZ: Float, hand: InteractionHand): InteractionResult = InteractionResult.PASS
-
-  @Deprecated
-  override def useOn(ctx: UseOnContext): InteractionResult =
-    ctx.getItemInHand match {
-      case stack: ItemStack => {
-        val world = ctx.getLevel
-        val pos = BlockPosition(ctx.getClickedPos, world)
-        val hitPos = ctx.getClickLocation
-        val success = onItemUse(stack, ctx.getPlayer, pos, ctx.getClickedFace,
-          (hitPos.x - pos.x).toFloat, (hitPos.y - pos.y).toFloat, (hitPos.z - pos.z).toFloat)
-        if (success) InteractionResult.sidedSuccess(world.isClientSide) else InteractionResult.PASS
-      }
-      case _ => super.useOn(ctx)
-    }
-
-  @Deprecated
-  def onItemUse(stack: ItemStack, player: Player, position: BlockPosition, side: Direction, hitX: Float, hitY: Float, hitZ: Float): Boolean = false
-
-  override def use(world: Level, player: Player, hand: InteractionHand): InteractionResultHolder[ItemStack] = use(player.getItemInHand(hand), world, player)
-
-  @Deprecated
-  def use(stack: ItemStack, level: Level, player: Player): InteractionResultHolder[ItemStack] =
-    new InteractionResultHolder(InteractionResult.PASS, stack)
-
   protected def tierFromDriver(stack: ItemStack): Int =
     api.Driver.driverFor(stack) match {
       case driver: api.driver.DriverItem => driver.tier(stack)
@@ -93,7 +48,6 @@ trait SimpleItem extends Item with api.driver.item.UpgradeRenderer with IItemExt
 
   protected def tooltipData = Seq.empty[Any]
 
-  @OnlyIn(Dist.CLIENT)
   override def appendHoverText(stack: ItemStack, context: TooltipContext, tooltip: util.List[Component], flag: TooltipFlag): Unit = {
     if (tooltipName.isDefined) {
       for (curr <- Tooltip.get(tooltipName.get, tooltipData: _*)) {

--- a/src/main/scala/li/cil/oc/common/item/traits/SimpleItem.scala
+++ b/src/main/scala/li/cil/oc/common/item/traits/SimpleItem.scala
@@ -77,6 +77,8 @@ trait SimpleItem extends Item with api.driver.item.UpgradeRenderer with IItemExt
   @Deprecated
   def onItemUse(stack: ItemStack, player: Player, position: BlockPosition, side: Direction, hitX: Float, hitY: Float, hitZ: Float): Boolean = false
 
+  override def use(world: Level, player: Player, hand: InteractionHand): InteractionResultHolder[ItemStack] = use(player.getItemInHand(hand), world, player)
+
   @Deprecated
   def use(stack: ItemStack, level: Level, player: Player): InteractionResultHolder[ItemStack] =
     new InteractionResultHolder(InteractionResult.PASS, stack)


### PR DESCRIPTION
`SimpleItem` defines several overrides for the various use-item methods. This can make code unidiomatic (several places where we don't correctly handle items in the off-hand) and just makes the code a bit more confusing to reason about.