### PR TITLE
Fix floppy disk in drive not restoring visually in-world on reload

### DIFF
--- a/src/main/scala/li/cil/oc/common/blockentity/DiskDrive.scala
+++ b/src/main/scala/li/cil/oc/common/blockentity/DiskDrive.scala
@@ -137,21 +137,4 @@ class DiskDrive(pos: BlockPos, state: BlockState)
       Sound.playDiskEject(this)
     }
   }
-
-  // ----------------------------------------------------------------------- //
-  // TileEntity
-
-  private final val DiskTag = Settings.namespace + "disk"
-
-  override def loadForClient(nbt: CompoundTag, provider: HolderLookup.Provider): Unit = {
-    super.loadForClient(nbt, provider)
-    if (nbt.contains(DiskTag)) {
-      setItem(0, ItemStack.parseOptional(provider, nbt.getCompound(DiskTag)))
-    }
-  }
-
-  override def saveForClient(nbt: CompoundTag, provider: HolderLookup.Provider): Unit = {
-    super.saveForClient(nbt, provider)
-    if (!items(0).isEmpty) nbt.setNewCompoundTag(DiskTag, _ => items(0).save(provider))
-  }
 }


### PR DESCRIPTION
Attempts to fix an issue where the floppy disk does not visually restore in-world on disk drive reload (save+quit, server relog, etc).