### PR TITLE
Fix usages of ItemStack.save with setNewCompoundTag

### DIFF
--- a/src/main/scala/li/cil/oc/common/blockentity/Assembler.scala
+++ b/src/main/scala/li/cil/oc/common/blockentity/Assembler.scala
@@ -33,7 +33,7 @@ import net.neoforged.neoforge.common.extensions.IBlockEntityExtension
 
 import scala.jdk.CollectionConverters._
 
-class Assembler(pos: BlockPos, state: BlockState) 
+class Assembler(pos: BlockPos, state: BlockState)
   extends BlockEntity(BlockEntityTypes.ASSEMBLER.get(), pos, state) with traits.Environment with traits.PowerAcceptor
   with traits.Inventory with SidedEnvironment with traits.StateAware with traits.Tickable with DeviceInfo with MenuProvider
     with IBlockEntityExtension {
@@ -172,7 +172,7 @@ class Assembler(pos: BlockPos, state: BlockState)
   override def saveForServer(nbt: CompoundTag, provider: HolderLookup.Provider): Unit = {
     super.saveForServer(nbt, provider)
     if (!output.isEmpty) {
-      nbt.setNewCompoundTag(OutputTag, _ => output.get.save(provider))
+      nbt.put(OutputTag, output.get.save(provider))
     }
     else {
       nbt.remove(OutputTag)

--- a/src/main/scala/li/cil/oc/common/blockentity/Printer.scala
+++ b/src/main/scala/li/cil/oc/common/blockentity/Printer.scala
@@ -26,7 +26,7 @@ import net.neoforged.neoforge.common.extensions.IBlockEntityExtension
 import java.util
 import scala.collection.convert.ImplicitConversionsToJava._
 
-class Printer(pos: BlockPos, state: BlockState) 
+class Printer(pos: BlockPos, state: BlockState)
   extends BlockEntity(BlockEntityTypes.PRINTER.get(), pos, state) with traits.Environment with traits.Inventory with traits.Rotatable
   with SidedEnvironment with traits.StateAware with traits.Tickable with WorldlyContainer with DeviceInfo with MenuProvider
     with IBlockEntityExtension {
@@ -339,7 +339,7 @@ class Printer(pos: BlockPos, state: BlockState)
     nbt.setNewCompoundTag(DataTag, (nbt: CompoundTag) => data.saveData(nbt, provider))
     nbt.putBoolean(IsActiveTag, isActive)
     nbt.putInt(LimitTag, limit)
-    output.foreach(stack => nbt.setNewCompoundTag(OutputTag, _ => stack.save(provider)))
+    output.foreach(stack => nbt.put(OutputTag, stack.save(provider)))
     nbt.putDouble(TotalTag, totalRequiredEnergy)
     nbt.putDouble(RemainingTag, requiredEnergy)
   }

--- a/src/main/scala/li/cil/oc/util/ExtendedNBT.scala
+++ b/src/main/scala/li/cil/oc/util/ExtendedNBT.scala
@@ -215,7 +215,7 @@ object ExtendedNBT {
   }
 
   class ExtendedCompoundTag(val nbt: CompoundTag) {
-    def setNewCompoundTag(name: String, f: CompoundTag => Any) = {
+    def setNewCompoundTag(name: String, f: CompoundTag => Unit) = {
       val t = new CompoundTag()
       f(t)
       nbt.put(name, t)


### PR DESCRIPTION
`setNewCompoundTag(key, tag => ...)` expects the lambda to mutate the tag. However, we were calling this like `setNewCompoundTag(key, _ => stack.save(registries))`, which means we never actually save the stack. The correct usage should either be `.put(stack.save(...))` (which is what we use here) or `.setNewCompoundTag(stack.save(..., _))`.

This is the cause of #64 too, but in that case deleting the overrides is sufficient.