### PR TITLE
Resolution adjustments

### DIFF
--- a/src/main/resources/data/opencomputers/opencomputers/loot_disks/openos/bin/resolution.lua
+++ b/src/main/resources/data/opencomputers/opencomputers/loot_disks/openos/bin/resolution.lua
@@ -1,8 +1,20 @@
 local shell = require("shell")
 local tty = require("tty")
 
-local args = shell.parse(...)
+local args, ops = shell.parse(...)
 local gpu = tty.gpu()
+
+if ops["max"] then
+  local w, h = gpu.maxResolution()
+  io.write(w," ",h,"\n")
+  -- Give a diagnostic for whether or not the capabilities of the screen and GPU
+  -- are mismatched
+  local limiter = gpu.capabilityLimiter()
+  if limiter then
+    io.write("(Limited by ",limiter,")\n")
+  end
+  return
+end
 
 if #args == 0 then
   local w, h = gpu.getViewport()
@@ -11,7 +23,7 @@ if #args == 0 then
 end
 
 if #args ~= 2 then
-  print("Usage: resolution [<width> <height>]")
+  print("Usage: resolution [<width> <height>] or resolution --max")
   return
 end
 

--- a/src/main/resources/data/opencomputers/opencomputers/loot_disks/openos/bin/resolution.lua
+++ b/src/main/resources/data/opencomputers/opencomputers/loot_disks/openos/bin/resolution.lua
@@ -7,8 +7,6 @@ local gpu = tty.gpu()
 if ops["max"] then
   local w, h = gpu.maxResolution()
   io.write(w," ",h,"\n")
-  -- Give a diagnostic for whether or not the capabilities of the screen and GPU
-  -- are mismatched
   local limiter = gpu.capabilityLimiter()
   if limiter then
     io.write("(Limited by ",limiter,")\n")

--- a/src/main/resources/data/opencomputers/opencomputers/loot_disks/openos/lib/core/boot.lua
+++ b/src/main/resources/data/opencomputers/opencomputers/loot_disks/openos/lib/core/boot.lua
@@ -31,7 +31,7 @@ if gpu then
   end
   _G.boot_screen = gpu.getScreen()
   w, h = gpu.maxResolution()
-  gpu.setResolution(w, h)
+  gpu.setResolution(math.min(w, 80), math.min(h, 25))
   gpu.setBackground(0x000000)
   gpu.setForeground(0xFFFFFF)
   gpu.fill(1, 1, w, h, " ")

--- a/src/main/resources/data/opencomputers/opencomputers/loot_disks/openos/lib/core/boot.lua
+++ b/src/main/resources/data/opencomputers/opencomputers/loot_disks/openos/lib/core/boot.lua
@@ -31,7 +31,7 @@ if gpu then
   end
   _G.boot_screen = gpu.getScreen()
   w, h = gpu.maxResolution()
-  gpu.setResolution(math.min(w, 80), math.min(h, 25))
+  gpu.setResolution(w, h)
   gpu.setBackground(0x000000)
   gpu.setForeground(0xFFFFFF)
   gpu.fill(1, 1, w, h, " ")

--- a/src/main/scala/li/cil/oc/server/component/GraphicsCard.scala
+++ b/src/main/scala/li/cil/oc/server/component/GraphicsCard.scala
@@ -436,6 +436,25 @@ class GraphicsCard(val tier: Int, val vramScreens: Option[Double] = None, val vi
       result(math.min(gmw, smw), math.min(gmh, smh))
     })
 
+  @Callback(direct = true, doc = """function():string or nil -- Return which of GPU or screen is limiting display capabilities, if either""")
+  def capabilityLimiter(context: Context, args: Arguments): Array[AnyRef] =
+    // FIXME: Assumes that GPU/screen tiers do not differ only by color depth,
+    // which is *currently* valid but may not be in the future. It would be
+    // better to just use the tier values directly, but I couldn't figure out
+    // how to access the physical screen from the TextBuffer...
+    screen(s => {
+      val gmw = maxResolution._1
+      val smw = s.getMaximumWidth
+      result(
+        if (gmw > smw)
+          "screen"
+        else if (gmw < smw)
+          "gpu"
+        else // Equal, so neither is limiting
+          null
+      )
+    })
+
   @Callback(direct = true, doc = """function():number, number -- Get the current viewport resolution.""")
   def getViewport(context: Context, args: Arguments): Array[AnyRef] =
     screen(s => result(s.getViewportWidth, s.getViewportHeight))


### PR DESCRIPTION
Multi-item PR to make using higher tier screens nicer in OpenOS:
- ~~Limit OpenOS to 80x25 at boot time. T3 screens can be mildly uncomfortable to use at full resolution on a 1080p screen at moderate GUI scale, and T4 is even worse. It is still possible - just as before - to use the `resolution` program to set the resolution manually at any time.~~ Undid this, as there was disagreement about this being the correct solution for the downscaling issues it was trying to fix. We're gonna try solving this a different way later.
- Add a new GPU driver function - `gpu.capabilityLimiter()` - to quickly determine if there is a GPU/screen tier mismatch. Returns `"gpu"` if screen tier > GPU tier, `"screen"` if GPU tier > screen tier, or `nil` if they are matched in capability. This is theoretically something you could have already done, but it required grovelling through `computer.getDeviceInfo()` and knowing the precise values of the 'product name' for each GPU and APU and their max resolution widths, and would break if any of these predicating assumptions ever changed (unlikely, but still annoying).
- Enhance the `resolution` program to take a `--max` parameter to tell you the maximum supported system resolution, and using the new driver feature, whether or not you have a bottleneck in your hardware setup. It just plain wasn't able to do this before; it could only set a chosen resolution or return the current resolution. More necessary now that OpenOS no longer boots to the display's max resolution and thus max resolution needs to be more discoverable, but was otherwise an (IMO) sorely needed QoL enhancement.