### PR TITLE
Fix SSDs not illuminating the disk activity light on computer cases

### DIFF
--- a/src/main/scala/li/cil/oc/server/component/FileSystem.scala
+++ b/src/main/scala/li/cil/oc/server/component/FileSystem.scala
@@ -348,6 +348,7 @@ class FileSystem(val fileSystem: IFileSystem, var label: Label, val host: Option
   private def diskActivity(): Unit = {
     (sound, host) match {
       case (Some(s), Some(h)) => ServerPacketSender.sendFileSystemActivity(node, h, s)
+      case (None, Some(h)) => ServerPacketSender.sendFileSystemActivity(node, h)
       case _ =>
     }
   }


### PR DESCRIPTION
File system access with a null sound would previously not illuminate the disk activity light on computer cases.  Now both SSDs and tmpfs illuminate the light;  if this is undesirable behavior there are other fixes but I think it's reasonable.

Edit: see #70 for a fix that doesn't illuminate the light on tmpfs access.