### PR TITLE
Fix SSDs not illuminating the disk activity light on computer cases (alternative fix)

### DIFF
--- a/src/main/scala/li/cil/oc/integration/opencomputers/DriverFileSystem.scala
+++ b/src/main/scala/li/cil/oc/integration/opencomputers/DriverFileSystem.scala
@@ -80,8 +80,8 @@ object DriverFileSystem extends Item {
       var label: api.fs.Label = new ReadWriteItemLabel(stack)
       val isFloppy = api.Items.get(stack) == api.Items.get(Constants.ItemName.Floppy)
       val isSSD = stack.getItem.isInstanceOf[SolidStateDrive]
-      val sound = if (isSSD) None
-      else Some(Settings.resourceDomain + ":" + (if (isFloppy) "floppy_access" else "hdd_access"))
+      // ssd_access sound event is intentionally not provided, so they're silent
+      val sound = Some(Settings.resourceDomain + ":" + (if (isFloppy) "floppy_access" else if (isSSD) "ssd_access" else "hdd_access"))
       val drive = new DriveData(stack)
       val environment = if (drive.isUnmanaged) {
         new Drive(capacity max 0, platterCount, label, Option(host), sound, speed, drive.isLocked, isSSD)


### PR DESCRIPTION
See #69 for a description of the issue.

This fix uses a nonexistent soundEvent (currently `opencomputers:ssd_access`) so that the FileSystemAccessEvent sent from the SSD passes existing checks to light up the case light, but doesn't play a sound.  The advantage of doing it this way is that the computer case's internal tmpfs does *not* light up the disk access indicator light.  It does result in one console warning about being `Unable to play unknown soundEvent: opencomputers:ssd_access`, but I think that's okay?

If neither of my one-liners are good enough there are of course more ways to fix this with slightly deeper changes.