### PR TITLE
Resolution adjustments v2

### DIFF
--- a/src/main/resources/data/opencomputers/opencomputers/loot_disks/openos/bin/resolution.lua
+++ b/src/main/resources/data/opencomputers/opencomputers/loot_disks/openos/bin/resolution.lua
@@ -1,8 +1,27 @@
 local shell = require("shell")
 local tty = require("tty")
 
-local args = shell.parse(...)
+local args, ops = shell.parse(...)
 local gpu = tty.gpu()
+
+if ops["max"] or ops["m"] then
+  local w, h = gpu.maxResolution()
+  io.write(w," ",h,"\n")
+  local limited = nil
+  local gw, gh = gpu.hardwareResolution()
+  -- Only loads this when we need it
+  local component = require("component")
+  local sw, sh = component.invoke(tty.screen(), "hardwareResolution")
+  if gw < sw or gh < sh then
+    limited = "GPU"
+  elseif gw > sw or gh > sh then
+    limited = "screen"
+  end
+  if limited then
+    io.write("(Limited by ",limited,")\n")
+  end
+  return
+end
 
 if #args == 0 then
   local w, h = gpu.getViewport()
@@ -11,7 +30,7 @@ if #args == 0 then
 end
 
 if #args ~= 2 then
-  print("Usage: resolution [<width> <height>]")
+  print("Usage: resolution [<width> <height>] or resolution --max")
   return
 end
 

--- a/src/main/scala/li/cil/oc/common/component/TextBuffer.scala
+++ b/src/main/scala/li/cil/oc/common/component/TextBuffer.scala
@@ -239,6 +239,16 @@ class TextBuffer(val host: EnvironmentHost) extends AbstractManagedEnvironment w
     else result((), "unsupported operation")
   }
 
+  @Callback(doc = """function():number -- Get the maximum resolution supported by the screen.""")
+  def hardwareResolution(context: Context, args: Arguments): Array[AnyRef] = {
+    val (smw, smh) = maxResolution
+    result(smw, smh)
+  }
+
+  @Callback(direct = true, doc = """function():number -- Get the maximum color depth supported by the screen.""")
+  def hardwareDepth(context: Context, args: Arguments): Array[AnyRef] =
+    result(PackedColor.Depth.bits(maxDepth))
+
   // ----------------------------------------------------------------------- //
 
   override def setEnergyCostPerTick(value: Double): Unit = {

--- a/src/main/scala/li/cil/oc/server/component/GraphicsCard.scala
+++ b/src/main/scala/li/cil/oc/server/component/GraphicsCard.scala
@@ -407,9 +407,13 @@ class GraphicsCard(val tier: Int, val vramScreens: Option[Double] = None, val vi
     })
   }
 
-  @Callback(direct = true, doc = """function():number -- Get the maximum supported color depth.""")
+  @Callback(direct = true, doc = """function():number -- Get the maximum supported color depth by the current GPU+screen combo.""")
   def maxDepth(context: Context, args: Arguments): Array[AnyRef] =
     screen(s => result(PackedColor.Depth.bits(api.internal.TextBuffer.ColorDepth.values.apply(math.min(maxDepth.ordinal, s.getMaximumColorDepth.ordinal)))))
+
+  @Callback(direct = true, doc = """function():number -- Get the maximum color depth supported by the GPU.""")
+  def hardwareDepth(context: Context, args: Arguments): Array[AnyRef] =
+    result(PackedColor.Depth.bits(maxDepth))
 
   @Callback(direct = true, doc = """function():number, number -- Get the current screen resolution.""")
   def getResolution(context: Context, args: Arguments): Array[AnyRef] =
@@ -427,7 +431,7 @@ class GraphicsCard(val tier: Int, val vramScreens: Option[Double] = None, val vi
     screen(s => result(s.setResolution(w, h)))
   }
 
-  @Callback(direct = true, doc = """function():number, number -- Get the maximum screen resolution.""")
+  @Callback(direct = true, doc = """function():number, number -- Get the maximum screen resolution supported by the current GPU+screen combo.""")
   def maxResolution(context: Context, args: Arguments): Array[AnyRef] =
     screen(s => {
       val (gmw, gmh) = maxResolution
@@ -435,6 +439,12 @@ class GraphicsCard(val tier: Int, val vramScreens: Option[Double] = None, val vi
       val smh = s.getMaximumHeight
       result(math.min(gmw, smw), math.min(gmh, smh))
     })
+
+    @Callback(direct = true, doc = """function():number, number -- Get the maximum screen resolution supported by the GPU.""")
+  def hardwareResolution(context: Context, args: Arguments): Array[AnyRef] = {
+    val (gmw, gmh) = maxResolution
+    result(gmw, gmh)
+  }
 
   @Callback(direct = true, doc = """function():number, number -- Get the current viewport resolution.""")
   def getViewport(context: Context, args: Arguments): Array[AnyRef] =


### PR DESCRIPTION
[ Rewrite of #68 using a different driver extension strategy. ]

Multi-item PR to make using higher tier screens nicer:
- Add new GPU driver functions - `hardwareResolution()` and `hardwareDepth()` - that always return the GPU's maximum supported resolution and depth respectively, *regardless* of the limits of the attached screen.
- Ditto for screens - same functions that do the same thing for the screen, regardless of the limits of the attached GPU.

This allows software to sanely query for the true maximum capabilities of your graphics hardware and be able to inform the user if one side or the other is bottlenecking the system. This is theoretically something you could have already done, but it required grovelling through `computer.getDeviceInfo()` and knowing the precise values of the 'product name' for each GPU and APU and their max resolution widths, and would break if any of these predicating assumptions ever changed (unlikely, but still annoying).

- Enhance `/bin/resolution` program to be able to query for maximum supported system resolution, and using the new driver features, whether or not you have a bottleneck.
 
It just plain wasn't able to do this before; it could only set a chosen resolution or return the current resolution. A sorely needed QoL enhancement that's been a decade coming.