### PR TITLE
Remove `text_input` signal

### DIFF
--- a/src/main/java/li/cil/oc/api/internal/TextBuffer.java
+++ b/src/main/java/li/cil/oc/api/internal/TextBuffer.java
@@ -571,18 +571,6 @@ public interface TextBuffer extends ManagedEnvironment, Persistable {
     void keyUp(char character, int code, Player player);
 
     /**
-     * Signals a code-point (text) event for the buffer.
-     * <br>
-     * On the client side this causes a packet to be sent to the server. On the
-     * server side this will trigger a message that will be picked up by
-     * keyboards, which will then cause a signal in attached machines.
-     *
-     * @param codePoint     the code point being typed.
-     * @param player        the player that typed the code point. Pass {@code null} on the client side.
-     */
-    void textInput(int codePoint, Player player);
-
-    /**
      * Signals a clipboard paste event for the buffer.
      * <br>
      * On the client side this causes a packet to be sent to the server. On the
@@ -667,7 +655,7 @@ public interface TextBuffer extends ManagedEnvironment, Persistable {
          */
         EightBit,
 
-        /** 
+        /**
          * 65536 colors (16-bit high color).
          */
         SixteenBit

--- a/src/main/scala/li/cil/oc/client/PacketSender.scala
+++ b/src/main/scala/li/cil/oc/client/PacketSender.scala
@@ -19,7 +19,7 @@ object PacketSender {
   // Timestamp after which the next clipboard message may be sent. Used to
   // avoid spamming large packets on key repeat.
   protected var clipboardCooldown = 0L
-  
+
   def sendComputerPower(computer: menu.Case, power: Boolean): Unit = {
     val pb = new SimplePacketBuilder(PacketType.ComputerPower)
 
@@ -86,15 +86,6 @@ object PacketSender {
     pb.writeUTF(address)
     pb.writeChar(char)
     pb.writeInt(code)
-
-    pb.sendToServer()
-  }
-
-  def sendTextInput(address: String, codePt: Int): Unit = {
-    val pb = new SimplePacketBuilder(PacketType.TextInput)
-
-    pb.writeUTF(address)
-    pb.writeInt(codePt)
 
     pb.sendToServer()
   }

--- a/src/main/scala/li/cil/oc/client/gui/traits/InputBuffer.scala
+++ b/src/main/scala/li/cil/oc/client/gui/traits/InputBuffer.scala
@@ -51,13 +51,6 @@ trait InputBuffer extends DisplayBuffer {
       // Flush either way as the next code point will be unrelated.
       flushQueuedKey()
     }
-    // text_input happens independent of key events
-    if (Character.isSurrogate(char)) {
-      // Convert two successive surrogates back into a code point.
-      if (Character.isHighSurrogate(char)) highSurrogate = char
-      else buffer.textInput(Character.toCodePoint(highSurrogate, char), null)
-    }
-    else buffer.textInput(char, null)
   }
 
   protected def flushQueuedKey(): Unit = {

--- a/src/main/scala/li/cil/oc/common/PacketType.scala
+++ b/src/main/scala/li/cil/oc/common/PacketType.scala
@@ -89,7 +89,6 @@ object PacketType extends Enumeration {
   DronePower,
   KeyDown,
   KeyUp,
-  TextInput,
   Clipboard,
   MachineItemStateRequest,
   MachineItemStateResponse,

--- a/src/main/scala/li/cil/oc/common/component/GpuTextBuffer.scala
+++ b/src/main/scala/li/cil/oc/common/component/GpuTextBuffer.scala
@@ -69,7 +69,6 @@ class GpuTextBuffer(val owner: String, val id: Int, val data: li.cil.oc.util.Tex
   override def isRenderingEnabled: Boolean = false
   override def keyDown(character: Char, code: Int, player: Player): Unit = {}
   override def keyUp(character: Char, code: Int, player: Player): Unit = {}
-  override def textInput(codePt: Int, player: Player): Unit = {}
   override def clipboard(value: String, player: Player): Unit = {}
   override def mouseDown(x: Double, y: Double, button: Int, player: Player): Unit = {}
   override def mouseDrag(x: Double, y: Double, button: Int, player: Player): Unit = {}

--- a/src/main/scala/li/cil/oc/common/component/TextBuffer.scala
+++ b/src/main/scala/li/cil/oc/common/component/TextBuffer.scala
@@ -414,9 +414,6 @@ class TextBuffer(val host: EnvironmentHost) extends AbstractManagedEnvironment w
   override def keyUp(character: Char, code: Int, player: Player): Unit =
     proxy.keyUp(character, code, player)
 
-  override def textInput(codePt: Int, player: Player): Unit =
-    proxy.textInput(codePt, player)
-
   override def clipboard(value: String, player: Player): Unit =
     proxy.clipboard(value, player)
 
@@ -690,8 +687,6 @@ object TextBuffer {
 
     def keyUp(character: Char, code: Int, player: Player): Unit
 
-    def textInput(codePt: Int, player: Player): Unit
-
     def clipboard(value: String, player: Player): Unit
 
     def mouseDown(x: Double, y: Double, button: Int, player: Player): Unit
@@ -787,11 +782,6 @@ object TextBuffer {
     override def keyUp(character: Char, code: Int, player: Player): Unit = {
       debug(s"{type = keyUp, char = $character, code = $code}")
       ClientPacketSender.sendKeyUp(nodeAddress, character, code)
-    }
-
-    override def textInput(codePt: Int, player: Player): Unit = {
-      debug(s"{type = textInput, codePt = $codePt}")
-      ClientPacketSender.sendTextInput(nodeAddress, codePt)
     }
 
     override def clipboard(value: String, player: Player): Unit = {
@@ -930,10 +920,6 @@ object TextBuffer {
 
     override def keyUp(character: Char, code: Int, player: Player): Unit = {
       sendToKeyboards("keyboard.keyUp", player, Char.box(character), Int.box(code))
-    }
-
-    override def textInput(codePt: Int, player: Player): Unit = {
-      sendToKeyboards("keyboard.textInput", player, Int.box(codePt))
     }
 
     override def clipboard(value: String, player: Player): Unit = {

--- a/src/main/scala/li/cil/oc/server/PacketHandler.scala
+++ b/src/main/scala/li/cil/oc/server/PacketHandler.scala
@@ -64,7 +64,6 @@ object PacketHandler extends CommonPacketHandler {
       case PacketType.DronePower => onDronePower(p)
       case PacketType.KeyDown => onKeyDown(p)
       case PacketType.KeyUp => onKeyUp(p)
-      case PacketType.TextInput => onTextInput(p)
       case PacketType.Clipboard => onClipboard(p)
       case PacketType.MachineItemStateRequest => onMachineItemStateRequest(p)
       case PacketType.MouseClickOrDrag => onMouseClick(p)
@@ -245,17 +244,6 @@ object PacketHandler extends CommonPacketHandler {
     ComponentTracker.get(p.player.level, address) match {
       case Some(buffer: api.internal.TextBuffer) if canInteractWith(buffer, p.player) => buffer.keyUp(key, code, p.player)
       case _ => // Invalid Packet
-    }
-  }
-
-  def onTextInput(p: PacketParser): Unit = {
-    val address = p.readUTF()
-    val codePt = p.readInt()
-    if (codePt >= 0 && codePt <= Character.MAX_CODE_POINT) {
-      ComponentTracker.get(p.player.level, address) match {
-        case Some(buffer: api.internal.TextBuffer) if canInteractWith(buffer, p.player) => buffer.textInput(codePt, p.player)
-        case _ => // Invalid Packet
-      }
     }
   }
 

--- a/src/main/scala/li/cil/oc/server/component/Keyboard.scala
+++ b/src/main/scala/li/cil/oc/server/component/Keyboard.scala
@@ -88,15 +88,6 @@ class Keyboard(val host: EnvironmentHost) extends AbstractManagedEnvironment wit
             }
           case _ =>
         }
-      case Array(p: Player, codePt: Integer) if message.name == "keyboard.textInput" =>
-        if (isUsableByPlayer(p)) {
-          if (Settings.get.inputUsername) {
-            signal(p, "text_input", new String(Character.toChars(codePt)), p.getName.getString)
-          }
-          else {
-            signal(p, "text_input", new String(Character.toChars(codePt)))
-          }
-        }
       case Array(p: Player, value: String) if message.name == "keyboard.clipboard" =>
         if (isUsableByPlayer(p)) {
           for (line <- value.linesWithSeparators) {


### PR DESCRIPTION
Is there a good reason for `text_input` to exist?  It's new enough that few if any programs use it and it doesn't really resemble other OpenComputers versions.  It's also not that useful - even for a simple text input function, you'd still have to query `key_down` signals for things like Return or Backspace or arrow keys.