### PR TITLE
Add max complexity for T3 drones

### DIFF
--- a/src/main/scala/li/cil/oc/common/template/DroneTemplate.scala
+++ b/src/main/scala/li/cil/oc/common/template/DroneTemplate.scala
@@ -162,9 +162,13 @@ object DroneTemplate extends Template {
   }
 
   override protected def maxComplexity(inventory: Container) =
-    if (caseTier(inventory) == Tier.Two) 8
-    else if (caseTier(inventory) == Tier.Five) 9001 // Creative
-    else 5
+    caseTier(inventory) match {
+      case Tier.One => 5
+      case Tier.Two => 8
+      case Tier.Three => 10
+      case Tier.Five => 9001 // Creative
+      case _ => throw new IllegalStateException("Given drone tier does not have defined complexity")
+    }
 
   override protected def caseTier(inventory: Container) = ItemUtils.caseTier(inventory.getItem(0))
 }


### PR DESCRIPTION
The base assembler template code has a `maxComplexity` method that does some sort of calculation for the complexity limit of an assembled computer. Robots use this unmodified, and tablets use it but further tweak it. Drones don't do this. For some reason - probably owing to not figuring out a way to sanely reuse the existing formula - they opt to just hardcode the complexities of each tier. Surprise surprise, the T3 drone (added as part of the Tier 4 equipment inherited from the vibeport) didn't have a complexity defined, so the existing implementation ended up falling back to the T1 complexity value. Give the T3 drone a complexity limit (10 complexity, chosen by fair dice roll) and hopefully add a guard clause that will cause someone to notice that something is amiss if we ever add another tier of equipment.

Fixes #85.