### PR TITLE
Map `()` to `nil` when converting callback results

### DIFF
--- a/src/main/scala/li/cil/oc/server/driver/Registry.scala
+++ b/src/main/scala/li/cil/oc/server/driver/Registry.scala
@@ -157,7 +157,7 @@ private[oc] object Registry extends api.detail.DriverAPI {
     }
     else {
       valueRef match {
-        case null | None => null
+        case null | () | None => null
         case arg: java.lang.Boolean => arg
         case arg: java.lang.Byte => arg
         case arg: java.lang.Character => arg


### PR DESCRIPTION
To return `nil` from a component `@Callback`, it has to pass either `null` or `None` to the `result` function, though previously all callbacks used `null` exclusively. The vibeport apparently didn't get the memo, so in its misguided attempt to stick to Scala conventions it replaced a bunch of these `null`s with `()`.

Now, `()` is neither `null` nor `None`, so the `Registry` did not map it to `nil`. In fact, the `Registry` didn't have an explicit `case` for it at all, so it defaulted to converting it to string. As a result, all those methods that the vibefork tampered with started returning `"()", errorMessage` instead of `nil, errorMessage`.

This PR fixes this by adding `()` to the list of values that represent `nil` (meaning now you can use either `null`, `None`, or `()`). However, the code remains inconsistent, as half the calls uses `()` and the other half keeps passing `null`. It might be a good idea to commit to either choice: replace `()` with `null` or vice versa. (I prefer `()` personally, FWIW.)