### PR TITLE
Allow cats to charge carpeted capacitors

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -622,20 +622,20 @@ opencomputers {
     }
 
     # Carpeted Capacitor settings
-    # Carpeted Capacitors generate power when sheep or ocelots walk on them
-    # Power is generated when at least 2 of a type of animal are present.
-    # A single sheep and a single ocelot generates no power. Note that a
-    # computer constantly flashing the screen from white to black drains
+    # Carpeted Capacitors generate power when sheep or ocelots/cats walk on
+    # them. Power is generated when at least 2 of a type of animal are
+    # present. A single sheep and a single ocelot/cat generates no power. Note
+    # that a computer constantly flashing the screen from white to black drains
     # approximately 36 units of power per second. Thus, as an example with the
-    # default values, it would take 12 carpeted capacitors and 24 sheep
-    # (2 each) to keep the charge rate. Or, 6 carpeted capacitors and 12
-    # ocelots to do the same. Values are: units of power per carpeted
-    # capacitor per second with 2 animals of a type.
+    # default values, it would take 12 carpeted capacitors and 24 sheep (2 each)
+    # to keep the charge rate. Or, 6 carpeted capacitors and 12 ocelots/cats to
+    # do the same. Values are: units of power per carpeted capacitor per second
+    # with 2 animals of a type.
     carpetedCapacitors {
       # Chance one animal (per capacitor) will take some damage per minute
       # Damage chance is only dealt when power is generated
       damageChance: 0.001
-      # power generated from ocelots
+      # power generated from ocelots/cats
       ocelotPower: 6
       # power generated from sheep
       sheepPower: 3

--- a/src/main/scala/li/cil/oc/common/blockentity/CarpetedCapacitor.scala
+++ b/src/main/scala/li/cil/oc/common/blockentity/CarpetedCapacitor.scala
@@ -6,6 +6,7 @@ import li.cil.oc.api.driver.DeviceInfo.DeviceAttribute
 import li.cil.oc.api.driver.DeviceInfo.DeviceClass
 import li.cil.oc.Settings
 import net.minecraft.world.entity.LivingEntity
+import net.minecraft.world.entity.animal.Cat
 import net.minecraft.world.entity.animal.Ocelot
 import net.minecraft.world.entity.animal.Sheep
 import net.minecraft.world.damagesource.DamageSource
@@ -60,7 +61,7 @@ class CarpetedCapacitor(pos: BlockPos, state: BlockState)
         .filter(_.isAlive)
         .toSet
       val sheepPower = energyFromGroup(entities.filter(_.isInstanceOf[Sheep]), Settings.get.sheepPower)
-      val ocelotPower = energyFromGroup(entities.filter(_.isInstanceOf[Ocelot]), Settings.get.ocelotPower)
+      val ocelotPower = energyFromGroup(entities.filter(e => e.isInstanceOf[Ocelot] || e.isInstanceOf[Cat]), Settings.get.ocelotPower)
       val totalPower = sheepPower + ocelotPower
       if (totalPower > 0) {
         node.changeBuffer(totalPower)


### PR DESCRIPTION
Cats became their own distinct mob type from ocelots in 1.14, so they stopped being able to charge carpeted capacitors. Fix this oversight.